### PR TITLE
Revert "feat: renamed --client parameter to --replica"

### DIFF
--- a/modules/developers-guide/pages/cli-reference.adoc
+++ b/modules/developers-guide/pages/cli-reference.adoc
@@ -73,7 +73,7 @@ Use the following subcommands to specify the operation you want to perform or to
 
 |`+cache+` |Manages the `+dfx+` cache on the local computer.
 
-|`+canister+` |Manages canisters deployed on a network replica.
+|`+canister+` |Manages canisters deployed on a network client.
 
 |`+config+` |Sets or changes configuration options for your current project.
 
@@ -195,7 +195,7 @@ The command displays output similar to the following:
 [source,bash]
 ----
 binding to: V4(192.168.47.1:5353)
-replica(s): http://127.0.0.1:8080/api
+client(s): http://127.0.0.1:8080/api 
 Webserver started...
 ----
 
@@ -520,7 +520,7 @@ Use the following subcommands to specify the operation you want to perform or to
 
 |`+help+` |Displays usage information message for a specified subcommand.
 
-|`+install+` |Installs compiled code as a canister on the replica.
+|`+install+` |Installs compiled code as a canister on the client.
 
 |`+request-status+` |Request the status of a call to a canister.
 |===
@@ -554,7 +554,7 @@ You can use the following optional flags with the `+dfx canister call+` command.
 [width="100%",cols="<31%,<69%",options="header"]
 |===
 |Flag |Description
-|`+–async+` |Enables you to continue without waiting for the result of the call to be returned by polling the replica.
+|`+–async+` |Enables you to continue without waiting for the result of the call to be returned by polling the client.
 
 |`+-h+`, `+–help+` |Displays usage information.
 
@@ -575,8 +575,8 @@ You can use the following options with the `+dfx canister call+` command.
 [width="100%",cols="<31%,<69%",options="header"]
 |===
 |Option |Description
-|`+--replica replica_address+` |Specifies the replica host name or IP address and port to connect to.
-This option enables you to override the replica setting specified in the `+dfx.json+` configuration file.
+|`+--client client_address+` |Specifies the client host name or IP address and port to connect to.
+This option enables you to override the client setting specified in the `+dfx.json+` configuration file. 
 
 |`+--type type+` |Specifies the data type for the argument when making the call using an argument. 
 The valid values are `+string+`, `+number+`, `+idl+`, and `+raw+`.
@@ -653,7 +653,7 @@ For example, to invoke the `+get+` method for a canister with a `+canister_name+
 dfx canister call counter get --async
 ----
 
-In this example, the command includes the `+--async+` option to indicate that you want to make a separate `+request-status+` call rather than waiting to poll the replica for the result.
+In this example, the command includes the `+--async+` option to indicate that you want to make a separate `+request-status+` call rather than waiting to poll the client for the result. 
 The `+--async+` option is useful when processing an operation might take some time to complete.
 The option enables you to continue performing other operations then check for the result using a separate `+dfx canister request-status+` command.
 The returned result will be displayed as the IDL textual format.
@@ -716,30 +716,30 @@ dfx canister call hello greet --type raw '4449444c00017103e29883'
 
 This example uses the raw data type to pass a hexadecimal to the `+greet+` function of the `+hello+` canister. 
 
-==== Overriding the default replica address
+==== Overriding the default client address
 
-If you want to send a call to a specific replica address and port number without changing the settings in your `+dfx.json+` configuration file, you can explicitly specify the replica using the `+--replica` option.
+If you want to send a call to a specific client address and port number without changing the settings in your `+dfx.json+` configuration file, you can explicitly specify the client using the `+--client` option.
 
-For example, you can specify the replica address by running a command similar to the following:
+For example, you can specify the client address by running a command similar to the following:
 
 ////
 [source,bash]
 ----
-dfx canister call --replica http://192.168.3.1:5678 counter get
+dfx canister call --client http://192.168.3.1:5678 counter get
 ----
 
-Note that you must specify the replica URL after the canister operation (`+call+`), and before the canister name (`+counter+`) and function (`+get+`).
+Note that you must specify the client URL after the canister operation (`+call+`), and before the canister name (`+counter+`) and function (`+get+`).
 ////
 [source,bash]
 ----
-dfx canister --replica http://192.168.3.1:5678 call counter get
+dfx canister --client http://192.168.3.1:5678 call counter get
 ----
 
-Note that you must specify the replica URL before the canister operation (`+call+`), canister name (`+counter+`), and function (`+get+`).
+Note that you must specify the client URL before the canister operation (`+call+`), canister name (`+counter+`), and function (`+get+`).
 
 == dfx canister install
 
-Use the `+dfx canister install+` command to install compiled code as a canister on the network replica.
+Use the `+dfx canister install+` command to install compiled code as a canister on the network client.
 
 === Basic usage
 
@@ -758,7 +758,7 @@ You can use the following optional flags with the `+dfx canister install+` comma
 |`+--all+` |Enables you to install multiple canisters at once if you have a project `dfx.json` file that includes multiple canisters.
 Note that you must specify `--all` or an individual canister name.
 
-|`+--async+` |Enables you to continue without waiting for the result of the installation to be returned by polling the replica.
+|`+--async+` |Enables you to continue without waiting for the result of the installation to be returned by polling the client.
 
 |`+-h+`, `+--help+` |Displays usage information.
 
@@ -819,26 +819,26 @@ This command submits a request to install the canister and returns a request ide
 
 You can then use the request identifier to check the status of the request at a later time, much like a tracking number if you were shipping a package.
 
-==== Overriding the default replica address
+==== Overriding the default client address
 
-If you want to install a canister using a specific replica address and port number without changing the settings in your `+dfx.json+` configuration file, you can explicitly specify the replica using the `+--replica` option.
+If you want to install a canister using a specific client address and port number without changing the settings in your `+dfx.json+` configuration file, you can explicitly specify the client using the `+--client` option.
 
-For example, you can specify the replica address by running a command similar to the following:
+For example, you can specify the client address by running a command similar to the following:
 ////
 [source,bash]
 ----
-dfx canister install --replica http://192.168.3.1:5678 --all
+dfx canister install --client http://192.168.3.1:5678 --all
 ----
 
-Note that you must specify the replica URL after the canister operation (`+install+`) and before the canister name or `+--all+` flag.
+Note that you must specify the client URL after the canister operation (`+install+`) and before the canister name or `+--all+` flag.
 ////
 
 [source,bash]
 ----
-dfx canister --replica http://192.168.3.1:5678 install --all
+dfx canister --client http://192.168.3.1:5678 install --all
 ----
 
-Note that you must specify the replica URL before the canister operation (`+install+`) and before the canister name or `+--all+` flag.
+Note that you must specify the client URL before the canister operation (`+install+`) and before the canister name or `+--all+` flag.
 
 == dfx canister request-status
 
@@ -963,7 +963,7 @@ The command returns the current value for the configuration option:
 "staging/"
 ----
 
-Similarly, you can change the name of the main source file or the port number for the local network replica by running commands similar to the following:
+Similarly, you can change the name of the main source file or the port number for the local network client by running commands similar to the following:
 
 [source,bash]
 ----

--- a/modules/developers-guide/pages/customize-projects.adoc
+++ b/modules/developers-guide/pages/customize-projects.adoc
@@ -104,7 +104,7 @@ If you change the path to the main program file or the name of the file itself, 
 
 == How to change the location for serving the application front-end
 
-You can change the default host name and port number for running the local {IC} replica processes and serving the application front-end by modifying settings in the `+dfx.json+` configuration file.
+You can change the default host name and port number for running the local {IC} client processes and serving the application front-end by modifying settings in the `+dfx.json+` configuration file.
 
 For example:
 

--- a/modules/developers-guide/pages/getting-started.adoc
+++ b/modules/developers-guide/pages/getting-started.adoc
@@ -11,7 +11,7 @@ March 2020 (Alpha)
 :sdk-short-name: DFINITY Canister SDK
 :sdk-long-name: DFINITY Canister Software Development Kit (SDK)
 
-The {sdk-long-name} provides tools, sample code, and documentation to help you create programs to run on a locally-deployed {IC} replica node.
+The {sdk-long-name} provides tools, sample code, and documentation to help you create programs to run on a locally-deployed {IC} client node.
 (You won’t be able to install your programs on an externally-managed Developer Network just yet, but that capability is coming soon.)
 
 By developing programs that run on the {platform}, you can deploy secure, tamper-proof applications and provide web-based services without the restrictions or expense of a proprietary infrastructure, the complexities of database management and maintenance, or the investment in hardware required to run enterprise-scale software.
@@ -354,7 +354,7 @@ In addition to these files, the `+dfx build+` command creates an `+idl_` directo
 
 == Start the local network and deploy
 
-You now have a program that can be deployed on your local replica network.
+You now have a program that can be deployed on your local client network.
 
 To deploy the program on your local network:
 
@@ -376,7 +376,7 @@ If you don't specify the `+--background+` option, you must open a new terminal s
 For example, if you are in the Terminal application on macOS, click Shell, then click *New Window*.
 You can then navigate to your `+hello_world+` project directory in the new terminal shell before continuing to the next step.
 +
-After you start the local network, you should see the `Internet Computer replica started` message and details about your current network configuration.
+After you start the local network, you should see the `Internet Computer client started` message and details about your current network configuration.
 . Deploy your `+hello_world+` project on the local network by running the `+dfx canister install+` command and specifying a `+canister_name+` that matches the canister name specified in the `+dfx.json+` configuration file.
 +
 For this tutorial, the canister name is `+hello_world+` and the path to the compiled code for the canister you want to deploy is `+canisters/hello_world/main.wasm+`, so you can deploy the canister by running the following command:
@@ -408,7 +408,7 @@ For example:
 ----
 ("*Hello, there!*")
 ----
-. Stop the {IC} replica processes running on your local computer by running the following command:
+. Stop the {IC} client processes running on your local computer by running the following command:
 +
 [source,bash]
 ----

--- a/modules/developers-guide/pages/glossary.adoc
+++ b/modules/developers-guide/pages/glossary.adoc
@@ -15,8 +15,8 @@ replica::
   In the context of the {platform}, a replica refers to the {IC} processes (for example, the `+replica+`, `+nodemanager+`, and other lower-level {IC} protocol processes) running on a physical computer node in the network.
   For the {sdk-short-name}, you use the `+dfx start+` and `+dfx stop+` commands to start and stop the `+replica+` process locally to provide a local network for development.
 node::
-  A physical computer that is a registered member of the {platform} network and running the {IC} replica processes.
+  A physical computer that is a registered member of the {platform} network and running the {IC} client processes.
 WebAssembly::
   https://webassembly.org/[WebAssembly] (`+Wasm+`) is a low-level computer instruction format. 
   Because WebAssembly defines a portable,open-standard, binary format that abstracts cleanly over most modern computer hardware, it is broadly supported for programs that run on the internet. 
-  Programs written in {proglang} are compiled to WebAssembly code for execution on {IC} replicas.
+  Programs written in {proglang} are compiled to WebAssembly code for execution on {IC} clients.

--- a/modules/developers-guide/pages/troubleshooting.adoc
+++ b/modules/developers-guide/pages/troubleshooting.adoc
@@ -88,7 +88,7 @@ Fixing memory leaks is an ongoing process. If you encounter any error messages r
 . Run `+dfx stop+` to stop currently running processes.
 . Uninstal `+dfx+` to prevent further degradation.
 . Re-install `+dfx+`
-. Run `+dfx start+` to restart replica processes.
+. Run `+dfx start+` to restart client processes.
 
 Alternatively, you can remove the `+.cache/dfinity+` directory and re-install the latest `+dfx+` binary.
 For example:

--- a/modules/developers-guide/pages/tutorials/actor-hello-world.adoc
+++ b/modules/developers-guide/pages/tutorials/actor-hello-world.adoc
@@ -15,7 +15,7 @@ ifdef::env-github,env-browser[:outfilesuffix:.adoc]
 :sdk-long-name: DFINITY Canister Software Development Kit (SDK)
 
 In link:../getting-started{outfilesuffix}[Getting started], you had your first look at a simple program for the {platform} involving an actor object and asynchronous messaging. 
-As the next step in learning to write programs that take advantage of actor-based messaging, this tutorial illustrates how to modify a traditional `+Hello, World!+` program to define an actor, then deploy and test your program using your local replica network.
+As the next step in learning to write programs that take advantage of actor-based messaging, this tutorial illustrates how to modify a traditional `+Hello, World!+` program to define an actor, then deploy and test your program using your local client network.
 
 == Before you begin
 
@@ -23,7 +23,7 @@ Before starting the tutorial, verify the following:
 
 * You have downloaded and installed the SDK as described in
 link:../getting-started{outfilesuffix}[Getting started].
-* You have stopped any network replica processes running on the local
+* You have stopped any network client processes running on the local
 computer.
 
 This tutorial takes approximately 20 minutes to complete.
@@ -125,7 +125,7 @@ For more information about using a query call, see link:../introduction-key-conc
 
 == Build and deploy the program
 
-You now have a program that you can compile into an executable WebAssembly module that you can deploy—using the canister model—on your local replica network.
+You now have a program that you can compile into an executable WebAssembly module that you can deploy—using the canister model—on your local client network.
 
 To build the program executable:
 
@@ -150,9 +150,9 @@ dfx canister install actor_hello
 
 == Query the canister
 
-You now have a program deployed as a *canister* on your local replica network and can test your program by using the `+dfx canister call+` commands.
+You now have a program deployed as a *canister* on your local client network and can test your program by using the `+dfx canister call+` commands.
 
-To test the program you have deployed on the local replica network:
+To test the program you have deployed on the local client network:
 
 . Use `+dfx canister call+` to call the `+hello+` function by running the following command:
 +

--- a/modules/developers-guide/pages/tutorials/calculator.adoc
+++ b/modules/developers-guide/pages/tutorials/calculator.adoc
@@ -35,7 +35,7 @@ Before starting the tutorial, verify the following:
 
 * You have downloaded and installed the SDK as described in
 link:../getting-started{outfilesuffix}[Getting started].
-* You have stopped any network replica processes running on the local
+* You have stopped any network client processes running on the local
 computer.
 
 This tutorial takes approximately 20 minutes to complete.
@@ -118,7 +118,7 @@ If you wanted to restrict the functions in this calculator code to only use posi
 
 == Build and deploy the program
 
-You now have a program that you can compile into an executable WebAssembly module that you can deploy—using the canister model—on your local replica network.
+You now have a program that you can compile into an executable WebAssembly module that you can deploy—using the canister model—on your local client network.
 
 To build the program executable:
 
@@ -151,9 +151,9 @@ dfx canister install calc
 
 == Verify calculator functions on the canister
 
-You now have a program deployed as a *canister* on your local replica network and can test your program by using `+dfx canister call+` commands.
+You now have a program deployed as a *canister* on your local client network and can test your program by using `+dfx canister call+` commands.
 
-To test the program you have deployed on the local replica network:
+To test the program you have deployed on the local client network:
 
 . Use the `+dfx canister call+` command to call the `+calc+` canister `+add+` function and pass it the input argument `+10+` of type `+number+` by running the following command:
 +

--- a/modules/developers-guide/pages/tutorials/counter-tutorial.adoc
+++ b/modules/developers-guide/pages/tutorials/counter-tutorial.adoc
@@ -30,10 +30,10 @@ Like the other sample programs, this tutorial demonstrates a simple, but realist
 * Create a new project.
 * Write a program that uses {proglang} code.
 * Compile the code into a WebAssembly module that you deploy.
-* Deploy the canister on the local network replica.
+* Deploy the canister on the local network client.
 * Invoke the canister methods to increment then read the value of a counter.
 
-The following diagram provides a simplified overview of the workflow passing from the developer’s command-line environment to the internet computer network replica deployed locally:
+The following diagram provides a simplified overview of the workflow passing from the developer’s command-line environment to the internet computer network client deployed locally:
 
 image:dev-work-flow-2.png[Overview of the developer work flow]
 
@@ -44,7 +44,7 @@ As the diagram suggests, the network infrastructure and the development environm
 Before starting the tutorial, verify the following:
 
 * You have downloaded and installed the SDK as described in link:../getting-started{outfilesuffix}[Getting started].
-* You have stopped any network replica processes running on the local computer.
+* You have stopped any network client processes running on the local computer.
 
 This tutorial takes approximately 20 minutes to complete.
 
@@ -159,7 +159,7 @@ include::example$counter.mo[]
 
 == Build and deploy the program
 
-You now have a Counter program that you can compile into an executable WebAssembly module and deploy on your local replica network.
+You now have a Counter program that you can compile into an executable WebAssembly module and deploy on your local client network.
 
 To build and deploy the program:
 
@@ -194,7 +194,7 @@ After running the `+dfx build+` command, your program is encapsulated in a uniqu
 ----
 ls -l canisters/my_counter
 ----
-. Start the {IC} network replica processes by running the following command:
+. Start the {IC} network client processes by running the following command:
 +
 [source,bash]
 ----
@@ -228,7 +228,7 @@ the current value of the `+currentValue+` variable on the deployed canister:
 dfx canister call my_counter get
 ----
 +
-Note that you could use the `+--async+` option with this command to indicate that you want to poll the replica for the result with a separate `+request-status+` call.
+Note that you could use the `+--async+` option with this command to indicate that you want to poll the client for the result with a separate `+request-status+` call. 
 By default, the `+dfx canister call+` command waits for the result rather than requiring you to make a separate `+request-status+` call. 
 +
 The command returns the current value of the `+currentValue+` variable as zero:

--- a/modules/developers-guide/pages/tutorials/custom-frontend.adoc
+++ b/modules/developers-guide/pages/tutorials/custom-frontend.adoc
@@ -166,7 +166,7 @@ The command displays output indicating that the build is successful.
 
 == Start the local network and deploy
 
-You now have a program that can be deployed on your local replica network.
+You now have a program that can be deployed on your local client network.
 
 To deploy the program on your local network:
 

--- a/modules/developers-guide/pages/tutorials/hello-location.adoc
+++ b/modules/developers-guide/pages/tutorials/hello-location.adoc
@@ -21,7 +21,7 @@ The tutorial also illustrates how you could modify the program to allow it to ac
 
 * You have downloaded and installed the SDK as described in
 link:../getting-started{outfilesuffix}[Getting started].
-* You have stopped any network replica processes running on the local computer.
+* You have stopped any network client processes running on the local computer.
 
 This tutorial takes approximately 20 minutes to complete.
 
@@ -103,7 +103,7 @@ actor {
 
 == Build and deploy the program
 
-You now have a program that you can compile into an executable WebAssembly module that you can deploy—using the canister model—on your local replica network.
+You now have a program that you can compile into an executable WebAssembly module that you can deploy—using the canister model—on your local client network.
 
 To build the program executable:
 
@@ -135,9 +135,9 @@ Installing code for canister hello_location, with canister_id ic:E75C3765B661880
 
 == Pass a string argument to the canister
 
-You now have a program deployed as a *canister* on your local replica network and can test your program by using `+dfx canister call+` commands.
+You now have a program deployed as a *canister* on your local client network and can test your program by using `+dfx canister call+` commands.
 
-To test the program you have deployed on the local replica network:
+To test the program you have deployed on the local client network:
 
 . Call the `+location+` method in the program and pass your `+city+` argument of type `+string+` by running the following command:
 +

--- a/modules/developers-guide/pages/tutorials/multiple-actors.adoc
+++ b/modules/developers-guide/pages/tutorials/multiple-actors.adoc
@@ -39,7 +39,7 @@ Before starting the tutorial, verify the following:
 
 * You have downloaded and installed the SDK as described in
 link:../getting-started{outfilesuffix}[Getting started].
-* You have stopped any network replica processes running on the local
+* You have stopped any network client processes running on the local
 computer.
 
 This tutorial takes approximately 20 minutes to complete.
@@ -153,7 +153,7 @@ include::example$multiple-actors/daemon/main.mo[]
 
 == Build all of the canisters in the project
 
-You now have a program that you can compile into an executable WebAssembly module that you can deploy on your local replica network.
+You now have a program that you can compile into an executable WebAssembly module that you can deploy on your local client network.
 
 To build the executable for each actor in the project:
 
@@ -212,9 +212,9 @@ Installing code for canister daemon, with canister_id ic:3A8E1ED1A2F0B12F4B
 
 == Verify deployment by calling functions
 
-You now have three programs deployed as a *canisters* on your local replica network and can test each program by using `+dfx canister call+` commands.
+You now have three programs deployed as a *canisters* on your local client network and can test each program by using `+dfx canister call+` commands.
 
-To test the programs you have deployed on the local replica network:
+To test the programs you have deployed on the local client network:
 
 . Use the `+dfx canister call+` command to call the canister `+assistant+` using the `+addTodo+` function and pass it the task you want to add by running the following command:
 +

--- a/modules/developers-guide/pages/tutorials/multiple-factorial-actors.adoc
+++ b/modules/developers-guide/pages/tutorials/multiple-factorial-actors.adoc
@@ -37,7 +37,7 @@ Before starting the tutorial, verify the following:
 
 * You have downloaded and installed the SDK as described in
 link:../getting-started{outfilesuffix}[Getting started].
-* You have stopped any network replica processes running on the local
+* You have stopped any network client processes running on the local
 computer.
 
 This tutorial takes approximately 20 minutes to complete.
@@ -152,7 +152,7 @@ include::example$multiple-actors/daemon/main.mo
 
 == Build all of the canisters in the project
 
-You now have a program that you can compile into an executable WebAssembly module that you can deploy on your local replica network.
+You now have a program that you can compile into an executable WebAssembly module that you can deploy on your local client network.
 
 To build the executable for each actor in the project:
 
@@ -202,9 +202,9 @@ dfx canister install --all
 
 == Verify deployment by calling functions
 
-You now have three programs deployed as a *canisters* on your local replica network and can test each program by using `+dfx canister call+` commands.
+You now have three programs deployed as a *canisters* on your local client network and can test each program by using `+dfx canister call+` commands.
 
-To test the programs you have deployed on the local replica network:
+To test the programs you have deployed on the local client network:
 
 . Use the `+dfx canister call+` command to call the canister `+assistant+` using the `+addTodo+` function and pass it the task you want to add by running the following command:
 +

--- a/modules/developers-guide/pages/tutorials/my-contacts.adoc
+++ b/modules/developers-guide/pages/tutorials/my-contacts.adoc
@@ -196,7 +196,7 @@ Bundling frontend assets in the canister
 
 == Start the local network and deploy
 
-You now have a program that can be deployed on your local replica network.
+You now have a program that can be deployed on your local client network.
 
 To deploy the program on your local network:
 

--- a/modules/developers-guide/pages/tutorials/phonebook.adoc
+++ b/modules/developers-guide/pages/tutorials/phonebook.adoc
@@ -31,7 +31,7 @@ Before starting the tutorial, verify the following:
 
 * You have downloaded and installed the SDK as described in
 link:../getting-started{outfilesuffix}[Getting started].
-* You have stopped any network replica processes running on the local
+* You have stopped any network client processes running on the local
 computer.
 
 This tutorial takes approximately 10 minutes to complete.
@@ -112,7 +112,7 @@ include::example$phonebook.mo[]
 
 == Build and deploy the program
 
-You now have a program that you can compile into an executable WebAssembly module that you can deploy on your local replica network.
+You now have a program that you can compile into an executable WebAssembly module that you can deploy on your local client network.
 
 To build the program executable:
 
@@ -155,9 +155,9 @@ dfx canister install phonebook
 
 == Add names and numbers using the insert function
 
-You now have a program deployed as a *canister* on your local replica network and can test your program by using `+dfx canister call+` commands.
+You now have a program deployed as a *canister* on your local client network and can test your program by using `+dfx canister call+` commands.
 
-To test the program you have deployed on the local replica network:
+To test the program you have deployed on the local client network:
 
 . Use the `+dfx canister call+` command to call the canister `+phonebook+` using the `+insert+` function and pass it a name and phone number by running the following command:
 +

--- a/modules/quickstart/pages/quickstart.adoc
+++ b/modules/quickstart/pages/quickstart.adoc
@@ -14,7 +14,7 @@ March 2020 (Alpha)
 ifdef::env-github,env-browser[:outfilesuffix:.adoc]
 
 [[quick-start-intro]]
-This {sdk-long-name} is an Alpha release that provides tools, sample code, and documentation to help you create programs to run on a *locally-deployed* {IC} replica node.
+This {sdk-long-name} is an Alpha release that provides tools, sample code, and documentation to help you create programs to run on a *locally-deployed* {IC} client node.
 
 IMPORTANT: For this *Alpha* release, only *macOS* and *Linux* platforms are supported. In addition, you won’t be able to install your programs on an externally-managed Developer Network just yet, but that capability is coming soon.
 
@@ -157,7 +157,7 @@ Bundling frontend assets in the canister
 [[start-the-local-network-and-deploy]]
 == Start the local network and deploy
 
-You now have a program that can be deployed on your local replica network.
+You now have a program that can be deployed on your local client network.
 
 [arabic]
 . Start the {IC} network on your local computer by running the following command:
@@ -170,7 +170,7 @@ dfx start --background
 Depending on your platform and local security settings, you might see a warning displayed. 
 If you are prompted to allow or deny incoming network connections, click *Allow*.
 +
-The `+--background+` option starts {IC} replica processes then runs them in the background so that you can continue to the next step without opening another terminal shell on your local computer.
+The `+--background+` option starts {IC} client processes then runs them in the background so that you can continue to the next step without opening another terminal shell on your local computer.
 . Deploy the default program on the local network by running the following command:
 +
 [source,bash]
@@ -210,7 +210,7 @@ Mar 04 15:43:52.779 INFO Created checkpoint @169984
 in 68.44148ms, StateManager: 1
 (*"Hello, there!"*)
 ----
-. Stop the {IC} replica processes running on your local computer by running the following command:
+. Stop the {IC} client processes running on your local computer by running the following command:
 +
 [source,bash]
 ----

--- a/modules/release-notes/pages/sdk-release-notes.adoc
+++ b/modules/release-notes/pages/sdk-release-notes.adoc
@@ -19,7 +19,7 @@ The {sdk-long-name} enables developers to develop applications for the {IC} usin
 The {sdk-short-name} provides everything you need to perform the following key tasks:
 
 - Author canisters in {proglang} and compile them to WebAssembly.
-- Run {IC} replica processes locally on your development computer.
+- Run {IC} client processes locally on your development computer.
 - Deploy compiled programs as standalone canisters and interact with the canisters using a command-line interface.
 
 This {release} version of the {sdk-long-name} is an interim update of the Alpha release recently shared with the development community and made available to the public for preliminary testing, demonstration, and exploration.


### PR DESCRIPTION
Reverts dfinity/docs#87 because the related PR (that changes the parameter) has not been merged and is still being discussed.