### PR TITLE
Remove to-do section, add link to to-do in the examples repo

### DIFF
--- a/modules/developers-guide/pages/sample-apps.adoc
+++ b/modules/developers-guide/pages/sample-apps.adoc
@@ -44,47 +44,11 @@ For projects that use the {proglang} programming language, see link:https://gith
 //* link:[Hex encoding and decoding]
 * link:https://github.com/dfinity/examples/tree/master/motoko/phone-book[Phone book]
 * link:https://github.com/dfinity/examples/tree/master/motoko/pubsub[Publish/subscribe]
-//* link:https://github.com/dfinity/examples/tree/master/motoko/simple_to_do[To-do checklist]
+* link:https://github.com/dfinity/examples/tree/master/motoko/simple_to_do[To-do checklist]
 
 == Additional sample applications
 
 This section includes sample code from projects that are not currently available in the public repository.
-
-=== To-do checklist
-
-The `+motoko-to-do+` project illustrates how to create a simple to-do checklist application using the {proglang} programming language.
-
-==== Source code
-
-This project is implemented using the following {proglang} source code files:
-
-- The xref:utils[utils.mo] file contains the core functions for adding, completing, and removing to-do items. 
-- The xref:types[types.mo] file defines the properties for `+ToDo+` items as a custom data type definition.
-- The xref:main[main.mo] file contains the actor definition and public functions that the compiled canister exposes.
-
-[[utils]]
-===== utils.mo
-
-[source,motoko]
-----
-include::example$motoko-to-do/utils.mo[]
-----
-
-[[types]]
-===== types.mo
-
-[source,motoko]
-----
-include::example$motoko-to-do/types.mo[]
-----
-
-[[main]]
-===== main.mo
-
-[source,motoko]
-----
-include::example$motoko-to-do/main.mo[]
-----
 
 === Hex encoding and decoding
 


### PR DESCRIPTION
**Overview**
Now that the to-do app in in the examples repo, uncomment the link and remove the included code.

**Requirements**
What requirements are necessary to consider this problem solved?

**Considered Solutions**
What solutions were considered?

**Recommended Solution**
What solution are you recommending? Why?

**Considerations**
What impact will this change have on security, performance, users (e.g. breaking changes) or the team (e.g. maintenance costs)?
