### PR TITLE
Fix canister call example in Quick start

### DIFF
--- a/modules/quickstart/pages/quickstart.adoc
+++ b/modules/quickstart/pages/quickstart.adoc
@@ -221,10 +221,10 @@ Installing code for canister hello_assets, with canister_id ic:04000000000000000
 +
 [source,bash]
 ----
-dfx canister call hello greet everyone
+dfx canister call hello greet --type string everyone
 ----
 +
-This example uses the `+dfx canister call+` command to pass "everyone" as an argument to the `+greet+` function.
+This example uses the `+dfx canister call+` command to pass "everyone" as a string argument to the `+greet+` function.
 . Verify the command displays the return value of the `+greet+` function.
 +
 For example:


### PR DESCRIPTION
I haven't even finished reading the Quick start and already found what seems like a (broken) legacy example. I quickly found the solution though, and would ❤ to share it!

**Problem**
Executing this snippet from the Quick start:
```
> dfx canister call hello greet everyone
```

Gives:
```
Invalid argument: Invalid IDL: IDL parser error: Unrecognized token `Id("everyone")` found at 0:8
```

**Why it happens**
When executing the `dfx canister call` command, the default argument type (`--type`) is `idl` which is incompatible with the example which tries to pass a string argument without saying it's a string.

I guess the default used to be `string` in the past?

**Solution**
This PR appends `--type=string` to the broken command, and now it's fixed!