### PR TITLE
Add --type argument to dfx call example

### DIFF
--- a/modules/quickstart/pages/quickstart.adoc
+++ b/modules/quickstart/pages/quickstart.adoc
@@ -226,7 +226,7 @@ Installing code for canister hello_assets, with canister_id ic:04000000000000000
 +
 [source,bash]
 ----
-dfx canister call hello greet everyone
+dfx canister call hello greet everyone --type string
 ----
 +
 This example uses the `+dfx canister call+` command to pass "everyone" as an argument to the `+greet+` function.


### PR DESCRIPTION
Add `--type string` to the dfx call example. 
Without it, the command returns an error:
`Invalid argument: Invalid IDL: IDL parser error: Unrecognized token `Id("everyone")` found at 0:8
Expected one of "("`

**Overview**
Why do we need this feature? What are we trying to accomplish?

**Requirements**
What requirements are necessary to consider this problem solved?

**Considered Solutions**
What solutions were considered?

**Recommended Solution**
What solution are you recommending? Why?

**Considerations**
What impact will this change have on security, performance, users (e.g. breaking changes) or the team (e.g. maintenance costs)?
