### PR TITLE
feature: clarify developers center => developer center

### DIFF
--- a/antora.yml
+++ b/antora.yml
@@ -1,5 +1,5 @@
 name: docs
-title: Developers Center
+title: Developer Center
 version: 'master'
 start_page: ROOT:index.adoc
 nav:

--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -1,1 +1,1 @@
-* xref:index.adoc[Developers Center]
+* xref:index.adoc[Developer Center]


### PR DESCRIPTION
Hey just wanted to make a quick edit, no rush on deploying. Scott Staton brought up this request

> As it is, it gives the impression that we might have been going for something like "Developer's Center." Eliminating the plural, which isn't necessary, would help. I’ve cleared this with M. Lee.
