### PR TITLE
Update quickstart doc for version 0.6.3

### DIFF
--- a/modules/quickstart/pages/quickstart.adoc
+++ b/modules/quickstart/pages/quickstart.adoc
@@ -82,7 +82,7 @@ dfx --version
 The command displays version information for the `+dfx+` command-line executable similar to the following:
 +
 ....
-dfx 0.6.2
+dfx 0.6.3
 ....
 . Preview usage information for the other `+dfx+` command-line sub-commands by running the following command:
 +


### PR DESCRIPTION
**Overview**
Just an update to the docs for the newest Dfinity SDK version

**Requirements**
N/A

**Considered Solutions**
N/A

**Recommended Solution**
Just ran through the quickstart steps and noticed that the version that was installed by the install script is 0.6.3, not 0.6.2 :)

**Considerations**
N/A
