### PR TITLE
Add `include": ["./src"],` to the sample-tsconfig.json

### DIFF
--- a/modules/developers-guide/examples/sample-tsconfig.json
+++ b/modules/developers-guide/examples/sample-tsconfig.json
@@ -5,6 +5,6 @@
       "lib": ["ES2018", "DOM"],  /* Specify library files to be included in the compilation. */
       "allowJs": true,           /* Allow javascript files to be compiled. */
       "jsx": "react",            /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */
-    }
+    },
+    "include": ["src/**/*"],
 }
-


### PR DESCRIPTION
This tells typescript to only care about files in ./src, and now exclude ./dist and ./webpack.conf.js.

Before this, I sometimes get errors like this from `tsc` and vscode ide

```
~/ic-projects/mobin  master ✗                                       6h45m ⚑  ⍉
▶ ./node_modules/.bin/tsc -b
error TS5055: Cannot write file '/Users/bengo/ic-projects/mobin/dist/mobin_assets/index.js' because it would overwrite input file.

error TS5055: Cannot write file '/Users/bengo/ic-projects/mobin/webpack.config.js' because it would overwrite input file.


Found 2 errors.
```

**Overview**
Why do we need this feature? What are we trying to accomplish?

* Make our documentation about customizing the frontend to use TypeScript result a more robust project

**Requirements**
What requirements are necessary to consider this problem solved?

* On this commit of this app canister: https://github.com/gobengo/mobin/commit/bf9477dcbe56e3475fbe9bf2e18c19c39ed34d8f
* Running `npx typescript -b` should not show any errors

**Considered Solutions**
What solutions were considered?

* only this one

**Recommended Solution**
What solution are you recommending? Why?

* It's the appropriate way of configuring typescript for this

**Considerations**
What impact will this change have on security, performance, users (e.g. breaking changes) or the team (e.g. maintenance costs)?

* users won't be able to add typescript files outside of ./src without reconfiguring this