### PR TITLE
Fix link to sdk-license-agreement.txt

### DIFF
--- a/modules/developers-guide/pages/install-upgrade-remove.adoc
+++ b/modules/developers-guide/pages/install-upgrade-remove.adoc
@@ -14,7 +14,7 @@ include::ROOT:page$download.adoc[leveloffset=0,tag=install]
 
 == Reviewing the license agreement
 
-The installation script prompts you to read and accept the link:https://sdk.dfinity.org/sdk-license-agreement[DFINITY Canister SDK License Agreement] before installing the `+dfx+` command-line interface executable and its dependencies on your local computer.
+The installation script prompts you to read and accept the link:https://sdk.dfinity.org/sdk-license-agreement.txt[DFINITY Canister SDK License Agreement] before installing the `+dfx+` command-line interface executable and its dependencies on your local computer.
 You must type `+y+` and press kbd:[Enter] to continue with the installation.
 
 After you accept the license agreement, the installation script displays information about the components being installed on the local computer.


### PR DESCRIPTION
Hi, I found a broken link in the online documentation and am submitting a pull request for a fix. 

Here are the details. 

This page:

[https://sdk.dfinity.org/docs/developers-guide/install-upgrade-remove.html](https://sdk.dfinity.org/docs/developers-guide/install-upgrade-remove.html)

Contains a link labeled "DFINITY Canister SDK License Agreement" that points to the following URL:

[https://sdk.dfinity.org/sdk-license-agreement](https://sdk.dfinity.org/sdk-license-agreement)

Currently, this link returns an error message, 

> Page Not Found
> 
> The page you’re looking for does not exist. It may have been moved.
> 
> If you arrived on this page by clicking on a link, please notify the owner of the site that the link is broken. If you typed the URL of this page manually, please double check that you entered the address correctly.

(Verified in Chrome and Firefox on macOS 10.14). 

However, when installing the sdk via the command line, the correct link can be found:

`sh -ci "$(curl -fsSL https://sdk.dfinity.org/install.sh)"`

> info: Executing DFINITY SDK install script, commit: c7ec140d77c03b30355b990290b4bbd39beaa202
> 
>  DFINITY SDK 
>  Please READ the following license: 
> 
> DFINITY Foundation -- All rights reserved. This is an ALPHA version
> of the DFINITY Canister Software Development Kit (SDK). Permission is hereby granted
> to use AS IS and only subject to the Alpha DFINITY Canister SDK License Agreement which
> can be found here [https://sdk.dfinity.org/sdk-license-agreement.txt]. It comes with NO WARRANTY.
> 
> 
> Do you agree and wish to install the DFINITY ALPHA SDK [y/N]?
> y
> 

The link noted in the install process ([https://sdk.dfinity.org/sdk-license-agreement.txt](https://sdk.dfinity.org/sdk-license-agreement.txt), i.e. with .txt extension) does in fact resolve to a .txt file for download. 

This pull request simply fixes the link in the web documentation to match the link provided in the sdk install process.



**Overview**
Why do we need this feature? What are we trying to accomplish?

This fixes a broken link so that users on the web will find the license agreement rather than a page not found message.


**Requirements**
What requirements are necessary to consider this problem solved?

Clicking the link should resolve to the downloadable .txt file, not a page not found error. 

**Considered Solutions**
What solutions were considered?

I imagine another solution might link to a separate page branded similarly to the rest of the site, with the license of the text in the body, rather than linking to the .txt file.  Browsers may or may not display the .txt file (i.e. may prompt to download). If so, it appears that page would need to be added to the docs repository. 

**Recommended Solution**
What solution are you recommending? Why?

Update the link to point to the same place as the cli install. It's a quicker, more immediate fix. And it keeps one location for the license, rather than having both a txt file referenced by the command line install and a separate page used by the site, easing maintenance. And it avoids needing to update the URL used in the command line install script.


**Considerations**
What impact will this change have on security, performance, users (e.g. breaking changes) or the team (e.g. maintenance costs)?

N/A
