### PR TITLE
Fix bug in calc sample code

### DIFF
--- a/modules/developers-guide/examples/calc_main.mo
+++ b/modules/developers-guide/examples/calc_main.mo
@@ -20,7 +20,9 @@ actor Calc {
 
     // Clear the calculator and reset to zero
     public func clearall() : async Int {
-    if (cell : Int != 0)
-       cell -= cell;
-    return cell};
+    if (cell : Int != 0) {
+      cell -= cell; cell
+    } else {
+      cell 
+    }
  };


### PR DESCRIPTION
Hi! Was working through the tutorials yesterday and found what looks to be a bug in the sample code. 

Details below:

[https://sdk.dfinity.org/docs/developers-guide/tutorials/calculator.html](https://sdk.dfinity.org/docs/developers-guide/tutorials/calculator.html)

Under "Modify the default program", step 4:

```
    public func clearall() : async Int {
        if (cell : Int != 0)
            cell -= cell;
        return cell};
    };
```

Above fails to build:

```
$ dfx build calc
Building canisters...
Build failed. Reason:
  Build step failed for canister 75hes-oqbaa-aaaaa-aaaaa-aaaaa-aaaaa-aaaaa-q with error: Build failed. Reason:
  Command "/<path>/.cache/dfinity/versions/0.6.7/moc" "/<path>/ic-projects/calc/src/calc/calc_main.mo" "-o" "/<path>/ic-projects/calc/.dfx/local/canisters/calc/calc.did" "--idl" "--actor-idl" "/<path>/ic-projects/calc/.dfx/local/canisters/idl/" "--actor-alias" "calc" "75hes-oqbaa-aaaaa-aaaaa-aaaaa-aaaaa-aaaaa-q" "--package" "base" "/<path>/.cache/dfinity/versions/0.6.7/base"

<path>/ic-projects/calc/src/calc/calc_main.mo:20.1-20.2: syntax error, unexpected token '}',
expected one of token or <phrase> sequence:
  <eof>
  seplist(<dec>,<semicolon>)
```

**Overview**
Why do we need this feature? What are we trying to accomplish?

Fixes a bug; helps newcomers to the technology work through the tutorials 

**Requirements**
What requirements are necessary to consider this problem solved?

Fix should compile, run, and work as expected given the tutorial explanations 

**Considered Solutions**
What solutions were considered?

There are actually several ways this could be coded, I believe. 

e.g., it could be a one-liner:

```if (cell: Int != 0) cell -= cell; cell else cell;``` 

above, or:

```if (cell: Int != 0) { cell -= cell; cell } else { cell };```

I think the above solution may be too dense (i.e. too much going on in one line) for a newcomer to Motoko. 

Another alternative could just use the if conditional without an else block, and then return the cell value:

```
if (cell : Int != 0) {
  cell -= cell;
}; 
cell 
```

This solution does illustrate a "gotcha" that could catch JavaScript developers - the semicolon at the end of the if block is required in Motoko, unlike in JS. But a tutorial may not be the best place to go into these details. 

**Recommended Solution**
What solution are you recommending? Why?

```
if (cell : Int != 0) {
  cell -= cell; cell
} else {
  cell 
}
```

The above is straightforward, and simple for those following a tutorial (and likely new to Motoko). Also, the format in the if block (make the mutation, semicolon, then place the value explicitly) follows the function definition conventions preceding in the same file.

Being new myself, I reviewed the Motoko styleguide:

[https://sdk.dfinity.org/docs/language-guide/style.html](https://sdk.dfinity.org/docs/language-guide/style.html)

> Braces
> 
> Put braces around function bodies, if or case branches, and loop bodies, 
> unless they appear nested as an expression and only contain a single expression.

Arguably, the one-liner noted above might work with the above recommendation. However, if we keep the statement resulting from the if conditional as `cell -= cell; cell` (which is similar in convention to the function blocks preceding in the same file) it is technically two statements. 

> Use "C-style" layout for braced sub-expressions stretching multiple lines. 

The proposed solution follows the above recommendation, since we do have multiple lines. 

Another solution could be one that is similar to the proposed solution, but with explicit "return" statements. I.e.:

```
 if (cell : Int != 0) {
   cell -= cell; 
   return cell
 } else {
  return cell 
}
```

Looking at the styleguide though, it does seem that our case is simple enough to not warrant the return statement:

> Motoko allows to omit the return at the end of a function, because a block evaluates to its last expression.
> 
> Use this when a function is short and in "functional" style, that is, 
> the function does not contain complex control flow or side effects.
> 
> Use explicit return at the end when the function contains other return statements or imperative control flow.

Our example does not contain particularly complex control flow or side effects. But for beginners, it may be useful to see the return statement. I imagine this could go either way. 

**Considerations**
What impact will this change have on security, performance, users (e.g. breaking changes) or the team (e.g. maintenance costs)?

This bugfix will help new developers working through the tutorials to understand the language. This will give them the correct code in the tutorial so that they don't have to troubleshoot and figure out one of the working solutions detailed above on their own. 
