### PR TITLE
Split up identity for better and more consistent navigation

### DIFF
--- a/modules/developers-guide/pages/cli-reference/dfx-identity.adoc
+++ b/modules/developers-guide/pages/cli-reference/dfx-identity.adoc
@@ -32,13 +32,13 @@ For reference information and examples that illustrate using `+dfx identity+` co
 
 |<<dfx identity list,`+list+`>> |Lists existing identities.
 
-|<<dfx identity new,`+new>> |Creates a new identity.
+|<<dfx identity new,`+new+`>> |Creates a new identity.
 
-|<<dfx identity remove,`+remove>> |Removes an existing identity.
+|<<dfx identity remove,`+remove+`>> |Removes an existing identity.
 
-|<<dfx identity rename,`+rename>> |Renames an existing identity.
+|<<dfx identity rename,`+rename+`>> |Renames an existing identity.
 
-|<<dfx identity use,`+use>> |Specifies the identity to use.
+|<<dfx identity use,`+use+`>> |Specifies the identity to use.
 
 |<<dfx identity whoami,`+whoami+`>> |Displays the name of the current identity user context.
 |===

--- a/modules/developers-guide/pages/cli-reference/dfx-identity.adoc
+++ b/modules/developers-guide/pages/cli-reference/dfx-identity.adoc
@@ -1,55 +1,49 @@
 = dfx identity
 :sdk-short-name: DFINITY Canister SDK
 
-Use the `+dfx identity+` command to manage the identities used to communicate with the Internet Computer network. 
+Use the `+dfx identity+` command with subcommands and flags to manage the identities used to execute commands and communicate with the Internet Computer network. 
 Creating multiple user identities enables you to test user-based access controls.
 
-== Basic usage
+The basic syntax for running `+dfx identity+` commands is:
 
 [source,bash]
 ----
 dfx identity [subcommand] [flag]
 ----
 
-== Flags
+Depending on the `+dfx identity+` subcommand you specify, additional arguments, options, and flags might apply or be required.
+To view usage information for a specific `+dfx identity+` subcommand, specify the subcommand and the `+--help+` flag.
+For example, to see usage information for `+dfx identity new+`, you can run the following command:
 
-You can use the following optional flags with the `+dfx identity+` command:
+[source,bash]
+----
+dfx identity new --help
+----
 
-[width="100%",cols="<32%,<68%",options="header"]
-|===
-|Flag |Description
-
-|`+-h+`, `+--help+` |Displays usage information.
-
-|`+-V+`, `+--version+` |Displays version information.
-|===
-
-== Subcommands
-
-Use the following subcommands to specify the operation you want to perform or to view usage information for a specific command.
+For reference information and examples that illustrate using `+dfx identity+` commands, select an appropriate command.
 
 [width="100%",cols="<32%,<68%",options="header"]
 |===
 |Command |Description
 
-| `+get-principal+` | Shows the textual representation of the Principal associated with the current identity.
+|<<dfx identity get-principal,`+get-principal+`>> | Shows the textual representation of the Principal associated with the current identity.
 
-| `+help+` |Displays this usage message or the help of the given subcommand(s).
+|`+help+` |Displays this usage message or the help of the given subcommand(s).
 
-|`+list+` |Lists existing identities.
+|<<dfx identity list,`+list+`>> |Lists existing identities.
 
-|`+new <identity_name>+` |Creates a new identity.
+|<<dfx identity new,`+new>> |Creates a new identity.
 
-|`+remove <identity_name>+` |Removes an existing identity.
+|<<dfx identity remove,`+remove>> |Removes an existing identity.
 
-|`+rename <from_name> <to_name>+` |Renames an existing identity.
+|<<dfx identity rename,`+rename>> |Renames an existing identity.
 
-|`+use <identity_name>+` |Specifies the identity to use.
+|<<dfx identity use,`+use>> |Specifies the identity to use.
 
-|`+whoami+` |Displays the name of the current identity user context.
+|<<dfx identity whoami,`+whoami+`>> |Displays the name of the current identity user context.
 |===
 
-=== Examples
+== Creating a default identity
 
 The first time you run the `+dfx canister create+` command to register an identifier, your public/private key pair credentials are used to create a `+default+` user identity.
 The credentials for the `+default+` user are migrated from `+$HOME/.dfinity/identity/creds.pem+` to `+$HOME/.config/dfx/identity/default/identity.pem+`.
@@ -63,26 +57,32 @@ dfx identity new ic_admin
 
 This command adds a private key for the `+ic_admin+` user identity in the `+~/.config/dfx/identity/ic_admin/identity.pem+` file.
 
-==== Renaming an identity
+== dfx identity get-principal
 
-You can rename the default user or any identity you have previously created using the `+dfx identity rename+` command.
-For example, if you want to rename a `+test_admin+` identity that you previously created, you would specify the current identity name you want to change **from** and the new name you want to change **to** by running a command similar to the following:
+Use the `+dfx identity get-principal+` command to display the textual representation of a principal associated with the current user identity context.
 
-....
-dfx identity rename test_admin ops
-....
+If you haven't created any user identities, you can use this command to display the principal for the `+default+` user.
+The textual representation of a principal can be useful for establishing and testing role-based authorization scenarios.
 
-==== Setting a user context
+=== Basic usage
 
-If you want to run multiple commands with the same user identity context, you can run a command similar to the following:
+[source,bash]
+----
+dfx identity get-principal [flag]
+----
 
-....
-dfx identity use ops
-....
+=== Flags
 
-After running this command, subsequent commands use the credentials and access controls associated with the `+ops+` user.
+You can use the following optional flags with the `+dfx identity get-principal+` command.
 
-==== Displaying an identity principal 
+[width="100%",cols="<32%,<68%",options="header"]
+|===
+|Flag |Description
+|`+-h+`, `+--help+` |Displays usage information.
+|`+-V+`, `+--version+` |Displays version information.
+|===
+
+=== Example
 
 If you want to display the textual representation of a principal associated with a specific user identity context, you can run commands similar to the following:
 
@@ -93,3 +93,302 @@ dfx identity get-principal
 ----
 
 In this example, the first command sets the user context to use the `+ic_admin+` identity. The second command then returns the principal associated with the `+ic_admin+` identity.
+
+== dfx identity list
+
+Use the `+dfx identity list+` command to display the list of user identities available.
+When you run this command, the list displays an asterisk (*) to indicate the currently active user context.
+You should note that identities are global. They are not confined to a specific project context.
+Therefore, you can use any identity listed by the `+dfx identity list+` command in any project.
+
+=== Basic usage
+
+[source,bash]
+----
+dfx identity list [flag]
+----
+
+=== Flags
+
+You can use the following optional flags with the `+dfx identity list+` command.
+
+[width="100%",cols="<32%,<68%",options="header"]
+|===
+|Flag |Description
+|`+-h+`, `+--help+` |Displays usage information.
+|`+-V+`, `+--version+` |Displays version information.
+|===
+
+=== Examples
+
+You can use the `+dfx identity list+` command to list all of the identities you have currently available and to determine which identity is being used as the currently-active user context for running `+dfx+` commands.
+For example, you can run the following command to list the identities available:
+
+[source,bash]
+----
+dfx identity list
+----
+
+This command displays the list of identities found similar to the following:
+
+[source,bash]
+----
+alice_auth
+bob_standard *
+default
+ic_admin
+----
+
+In this example, the `+bob_standard+` identity is the currently-active user context.
+After you run this command to determine the active user, you know that any additional `+dfx+` commands you run are executed using the principal associated with the `+bob_standard+` identity.
+
+== dfx identity new
+
+Use the `+dfx identity new+` command to add new user identities.
+You should note that the identities you add are global. They are not confined to a specific project context.
+Therefore, you can use any identity you add using the `+dfx identity new+` command in any project.
+
+=== Basic usage
+
+[source,bash]
+----
+dfx identity new [flag] _identity-name_
+----
+
+=== Flags
+
+You can use the following optional flags with the `+dfx identity new+` command.
+
+[width="100%",cols="<32%,<68%",options="header"]
+|===
+|Flag |Description
+|`+-h+`, `+--help+` |Displays usage information.
+|`+-V+`, `+--version+` |Displays version information.
+|===
+
+== Arguments
+
+You must specify the following argument for the `+dfx identity new+` command.
+
+[width="100%",cols="<32%,<68%",options="header"]
+|===
+|Argument |Description
+
+|`+<identity_name>+` |Specifies the name of the identity to create.
+This argument is required.
+
+|===
+
+=== Examples
+
+You can then use `+dfx identity new+` to create new user identities and store credentials for those identities in `+$HOME/.config/dfx/identity/<identity_name>/identity.pem+` files.
+For example, you can create an identity named `+ic_admin+` by running the following command:
+
+....
+dfx identity new ic_admin
+....
+
+This command adds a private key for the `+ic_admin+` user identity in the `+~/.config/dfx/identity/ic_admin/identity.pem+` file.
+
+After adding the private key for the new identity, the command displays confirmation that the identity has been created:
+
+....
+Creating identity: "ic_admin".
+Created identity: "ic_admin".
+....
+
+== dfx identity remove
+
+Use the `+dfx identity remove+` command to remove an existing user identity.
+You should note that the identities you add are global. They are not confined to a specific project context.
+Therefore, any identity you remove using the `+dfx identity remove+` command will no longer be available in any project.
+
+=== Basic usage
+
+[source,bash]
+----
+dfx identity remove [flag] _identity-name_
+----
+
+=== Flags
+
+You can use the following optional flags with the `+dfx identity remove+` command.
+
+[width="100%",cols="<32%,<68%",options="header"]
+|===
+|Flag |Description
+|`+-h+`, `+--help+` |Displays usage information.
+|`+-V+`, `+--version+` |Displays version information.
+|===
+
+== Arguments
+
+You must specify the following argument for the `+dfx identity remove+` command.
+
+[width="100%",cols="<32%,<68%",options="header"]
+|===
+|Argument |Description
+
+|`+<identity_name>+` |Specifies the name of the identity to remove.
+This argument is required.
+
+|===
+
+=== Examples
+
+You can use the `+dfx identity remove+` command to remove any previously-created identity, including the `+default+` user identity.
+For example, if you have added named user identities and want to remove the `+default+` user identity, you can run the following command:
+
+....
+dfx identity remove default
+....
+
+The command displays confirmation that the identity has been removed:
+
+....
+Removing identity "default".
+Removed identity "default".
+....
+
+Although you can delete the `+default+` identity if you have created other identities to replace it, you must always have at least one identity available.
+If you attempt to remove the last remaining user context, the `+dfx identity remove+` command displays an error similar to the following:
+
+....
+Identity error:
+  Cannot delete the default identity
+....
+
+== dfx identity rename
+
+Use the `+dfx identity rename+` command to rename an existing user identity.
+You should note that the identities you add are global. They are not confined to a specific project context.
+Therefore, any identity you rename using the `+dfx identity rename+` command is available using the new name in any project.
+
+=== Basic usage
+
+[source,bash]
+----
+dfx identity rename [flag] _from_identity-name_ _to_identity-name_
+----
+
+=== Flags
+
+You can use the following optional flags with the `+dfx identity rename+` command.
+
+[width="100%",cols="<32%,<68%",options="header"]
+|===
+|Flag |Description
+|`+-h+`, `+--help+` |Displays usage information.
+|`+-V+`, `+--version+` |Displays version information.
+|===
+
+== Arguments
+
+You must specify the following arguments for the `+dfx identity rename+` command.
+
+[width="100%",cols="<32%,<68%",options="header"]
+|===
+|Argument |Description
+
+|`+<from_identity_name>+` |Specifies the current name of the identity you want to rename.
+This argument is required.
+
+|`+<to_identity_name>+` |Specifies the new name of the identity you want to rename.
+This argument is required.
+
+|===
+
+=== Example
+
+You can rename the `+default+` user or any identity you have previously created using the `+dfx identity rename+` command.
+For example, if you want to rename a `+test_admin+` identity that you previously created, you would specify the current identity name you want to change **from** and the new name you want to change **to** by running a command similar to the following:
+
+....
+dfx identity rename test_admin devops
+....
+
+== dfx identity use
+
+Use the `+dfx identity use+` command to specify the user identity you want to active.
+You should note that the identities you have available to use are global. They are not confined to a specific project context.
+Therefore, you can use any identity you have previously created in any project.
+
+=== Basic usage
+
+[source,bash]
+----
+dfx identity use [flag] _identity-name_
+----
+
+=== Flags
+
+You can use the following optional flags with the `+dfx identity use+` command.
+
+[width="100%",cols="<32%,<68%",options="header"]
+|===
+|Flag |Description
+|`+-h+`, `+--help+` |Displays usage information.
+|`+-V+`, `+--version+` |Displays version information.
+|===
+
+== Arguments
+
+You must specify the following argument for the `+dfx identity use+` command.
+
+[width="100%",cols="<32%,<68%",options="header"]
+|===
+|Argument |Description
+
+|`+<identity_name>+` |Specifies the name of the identity you want to make active for subsequent commands.
+This argument is required.
+
+|===
+
+
+=== Examples
+
+If you want to run multiple commands with the same user identity context, you can run a command similar to the following:
+
+....
+dfx identity use ops
+....
+
+After running this command, subsequent commands use the credentials and access controls associated with the `+ops+` user.
+
+== dfx identity whoami
+
+Use the `+dfx identity whoami+` command to display the name of the currently-active user identity context.
+
+=== Basic usage
+
+[source,bash]
+----
+dfx identity whoami [flag]
+----
+
+=== Flags
+
+You can use the following optional flags with the `+dfx identity whoami+` command.
+
+[width="100%",cols="<32%,<68%",options="header"]
+|===
+|Flag |Description
+|`+-h+`, `+--help+` |Displays usage information.
+|`+-V+`, `+--version+` |Displays version information.
+|===
+
+=== Example
+
+If you want to display the name of the currently-active user identity, you can run the following command:
+
+[source,bash]
+----
+dfx identity whoami
+----
+
+The command displays the name of the user identity.
+For example, you had previously run the command `+dfx identity use bob_standard+`, the command would display:
+
+....
+bob_standard
+....

--- a/modules/developers-guide/pages/cli-reference/dfx-identity.adoc
+++ b/modules/developers-guide/pages/cli-reference/dfx-identity.adoc
@@ -166,7 +166,7 @@ You can use the following optional flags with the `+dfx identity new+` command.
 |`+-V+`, `+--version+` |Displays version information.
 |===
 
-== Arguments
+=== Arguments
 
 You must specify the following argument for the `+dfx identity new+` command.
 
@@ -221,7 +221,7 @@ You can use the following optional flags with the `+dfx identity remove+` comman
 |`+-V+`, `+--version+` |Displays version information.
 |===
 
-== Arguments
+=== Arguments
 
 You must specify the following argument for the `+dfx identity remove+` command.
 
@@ -282,7 +282,7 @@ You can use the following optional flags with the `+dfx identity rename+` comman
 |`+-V+`, `+--version+` |Displays version information.
 |===
 
-== Arguments
+=== Arguments
 
 You must specify the following arguments for the `+dfx identity rename+` command.
 
@@ -331,7 +331,7 @@ You can use the following optional flags with the `+dfx identity use+` command.
 |`+-V+`, `+--version+` |Displays version information.
 |===
 
-== Arguments
+=== Arguments
 
 You must specify the following argument for the `+dfx identity use+` command.
 

--- a/modules/developers-guide/pages/cli-reference/dfx-new.adoc
+++ b/modules/developers-guide/pages/cli-reference/dfx-new.adoc
@@ -34,7 +34,7 @@ If `+node.js+` is not currently installed, you can set this flag to `+true+` to 
 
 == Arguments
 
-You can specify the following argument for the `+dfx new+` command.
+You must specify the following argument for the `+dfx new+` command.
 
 [width="100%",cols="<32%,<68%",options="header"]
 |===


### PR DESCRIPTION
**Overview**
Add get-principal in the new dfx-identity file instead of in the single cli-reference file which was getting hard to navigate.
