### PR TITLE
Remove references to --skip-frontend

### DIFF
--- a/modules/developers-guide/pages/tutorials/calculator.adoc
+++ b/modules/developers-guide/pages/tutorials/calculator.adoc
@@ -164,7 +164,7 @@ To build and deploy the program:
 dfx build calc
 ----
 +
-For this tutorial, you can build your project using the `+--skip-frontend+` option because the project is a simple terminal-based applications that doesn't include any front-end assets.
+For this tutorial, you can build your project using the `+calc+` canister name because the project is a simple terminal-based applications that doesn't include any front-end assets.
 . Deploy your `+calc+` project on the local network by running the following command:
 +
 [source,bash]

--- a/modules/developers-guide/pages/tutorials/hello-location.adoc
+++ b/modules/developers-guide/pages/tutorials/hello-location.adoc
@@ -268,7 +268,6 @@ dfx build
 ----
 +
 For this tutorial, you have already removed the front-end assets canister, so running `+dfx build+` only compiles the `+favorite_cities+` canister.
-You can also build projects using the optional `+--skip-frontend+` argument if you are only interested in compiling back-end code for a project.
 . Deploy your `+favorite_cities+` program on the local network by running the following command:
 +
 [source,bash]

--- a/modules/developers-guide/pages/tutorials/phonebook.adoc
+++ b/modules/developers-guide/pages/tutorials/phonebook.adoc
@@ -145,7 +145,7 @@ To build and deploy the program:
 dfx build phonebook
 ----
 The `+dfx.json+` file provides default settings for creating an application front-end entry point and `+assets+` canister.
-For this tutorial, however, you can build your project using the `+--skip-frontend+` option because the project is a terminal-based application that doesn't include any front-end assets.
+For this tutorial, however, you can build your project using the `+phonebook+` canister name because the project is a terminal-based application that doesn't include any front-end assets.
 +
 Although this tutorial illustrates how to skip compiling a front-end canister, you can add a simple user interface to this application later by exploring the link:https://github.com/dfinity/examples/tree/master/motoko/phone-book[phone-book] project in the link:https://github.com/dfinity/examples[examples] repository.
 . Deploy your `+phonebook+` project on the local network by running the following command:

--- a/modules/developers-guide/pages/webpack-config.adoc
+++ b/modules/developers-guide/pages/webpack-config.adoc
@@ -53,7 +53,11 @@ import CANISTER-ALIAS from 'ic:canisters/CANISTER-ALIAS';
 
 Because projects rely on webpack to provide the framework for the default front-end, you must have `+node.js+` installed in your development environment and accessible in the project directory.
 
-* If you want to develop your project without using the default webpack configuration and canister aliases, you can build your project using the `+--skip-frontend+` command-line option.
+* If you want to develop your project without using the default webpack configuration and canister aliases, you can remove the `+assets+` canister from the `+dfx.json+` file or build your project using a specific canister name. For example, you can choose to build only the hello program without front-end assets by running the following command:
++
+....
+dfx build hello
+....
 
 * If you are using the default webpack configuration and running `+dfx build+` fails, you should try running `+npm install+` in the project directory then re-running `+dfx build+`.
 


### PR DESCRIPTION
**Overview**
Some leftover references to --skip-frontend that need to be removed now that it is retired.
\