### PR TITLE
DRAFT release notes for SDK 0.6.16 with updates to Motoko and motoko …

### DIFF
--- a/modules/release-notes/pages/sdk-release-notes.adoc
+++ b/modules/release-notes/pages/sdk-release-notes.adoc
@@ -44,7 +44,6 @@ This change enhances the security, interoperability, and future features that th
 +
 This change enables the Internet Computer to support different types of keys, including keys that are most commonly used for web authentication requests and keys that use cryptographic schemes that are better supported by hardware.
 The new encoding enables the {IC} to distinguish between the different types of keys that the {IC} supports.
-
 +
 This change also requires all principals to be regenerated to use the new encoding.
 If you have canisters deployed on the Internet Computer network or have canisters that use an existing principal for access control, you might need to do the following:
@@ -127,7 +126,7 @@ This change mostly affects interpreted programs and compiled programs with expli
 
 * Candid includes the ability to extend function with optional parameters in a backward-compatible way.
 
-* Injecting a value into an option type (`+? <exp>+`) no longer requires heap allocation in most cases. This removes the memory-tax of using iterators.																													
+* Injecting a value into an option type (`+? <exp>+`) no longer requires heap allocation in most cases. This removes the memory-tax of using iterators.
 
 For information about breaking changes that were introduced in previous releases, see <<Breaking changes>>.
 
@@ -137,7 +136,7 @@ For information about known issues that were introduced in previous releases, se
 
 The 0.6.14 release primarily includes internal enhancements and fixes and updates to the version of {proglang} and the {proglang} base library that are supported. 
 
-There are no user-visible new feature in this release. 
+There are no user-visible new features in this release. 
 
 === Highlights of what's new in 0.6.13
 

--- a/modules/release-notes/pages/sdk-release-notes.adoc
+++ b/modules/release-notes/pages/sdk-release-notes.adoc
@@ -50,7 +50,7 @@ If you have canisters deployed on the Internet Computer network or have canister
 +
 
 . Upgrade to the latest SDK release.
-. Update your projects to use the new dfx version.
+. Update your projects to use the new `+dfx+` version.
 . Update your applications to use the new principal format, if needed, or to pass it programmatically.
 . Recreate and redeploy your canisters.
 

--- a/modules/release-notes/pages/sdk-release-notes.adoc
+++ b/modules/release-notes/pages/sdk-release-notes.adoc
@@ -33,13 +33,111 @@ This {release} version of the software and programming language should not be us
 
 == Highlights of what's new in {release}
 
-The {release} release primarily includes internal enhancements and fixes and updates to the version of {proglang} and the {proglang} base library that are supported. 
+The {release} release primarily includes user-visible new features, internal enhancements, and fixes and updates to the version of {proglang} and the {proglang} base library that are supported. 
 
-There are no user-visible new feature in this release. 
+Some of the changes in the {release} are not backward-compatible and introduce breaking changes that might require you to update all existing projects or to modify {proglang} programs.
+
+The most significant new features and fixes include the following:
+
+* A new DER-based encoding format is used to generate principals. 
+This change enhances the security, interoperability, and future features that the Internet Computer can support.
++
+This change enables the Internet Computer to support different types of keys, including keys that are most commonly used for web authentication requests and keys that use cryptographic schemes that are better supported by hardware.
+The new encoding enables the {IC} to distinguish between the different types of keys that the {IC} supports.
+
++
+This change also requires all principals to be regenerated to use the new encoding.
+If you have canisters deployed on the Internet Computer network or have canisters that use an existing principal for access control, you might need to do the following:
++
+
+. Upgrade to the latest SDK release.
+. Update your projects to use the new dfx version.
+. Update your applications to use the new principal format, if needed, or to pass it programmatically.
+. Recreate and redeploy your canisters.
+
++
+If your canisters are deployed on the {IC} Developer Network (Sodium), you can use the updated canisters that use the new principal for a limited period of time without submitting the new principal or receiving an updated wallet canister.
+
+* To improve security, performance, and flexibility, there’s a 2MB restriction of the size of update messages. 
+In most cases, this restriction should not prevent you from building and deploying applications to run on the Internet Computer. 
+However, if you find this limitation hinders your ability to design and deploy canisters, contact DFINITY support with details about your use case and for help resolving the issue.
+
+* You can use an environment variable to configure the root directory for storing the `+.cache+` and `+.config+` subdirectories for `+dfx+`.
++
+By default, the `+.cache+` and `+.config+` directories are located in the home directory for your development environment. 
+For example, on macOS the default location is in the `+/Users/<YOUR-USER-NAME>+` directory.
+You can now use the `+DFX_CONFIG_ROOT+` environment variable to specify a different location for these directories.
+
+* Error handling has been improved.
+
+=== Motoko and Candid updates
+
+The {release} release includes changes to the version of {proglang}, the `+motoko-base+` library, and Candid included with the {sdk-short-name}.
+This version of {proglang} includes syntax changes that might require you to update existing programs.
+
+Key updates for {proglang} include support for the following features and changes:
+
+* Simple object literals of the form `+{a = foo(); b = bar()}+` no longer bind to field names locally. 
+This change enables you to write expressions like this:
++
+....
+func foo(a : Nat) { return {x = x} }.									
+....
++
+However, this new syntax breaks short-hand expressions such as:
++
+....
+`+{a = 1; b = a + 1}+`
+....
++
+Short-hand expressions like the one above must now be written differently for your program to compile.
+For example, you might modify the expression to use an auxiliary declaration like this:
++
+....
+let a = 1; {a = a; b = a + 1}
+....
++
+Alternatively, you could modify the program to use object syntax like this:
++
+....
+{public let a = 1; public let b = a + 1}
+....
+
+* Free-standing blocks are no longer allowed.
++
+With this release, blocks are only allowed as sub-expressions of control flow expressions such as `+if+`, `+loop+`, and `+case+`.
+In all other places, braces are always considered to start an object literal.																													
+To use blocks that are not part of control flow expressions, you can use `+do {<block>}+` expressions.
++
+In this release, free-standing blocks that are not part of a control flow expressions display a warning but continue to compile.
+However, you should update your programs to replace the deprecated syntax to ensure your program continues to compile after the compiler enforces the syntax change.
+
+* Actor declarations are asynchronous and can only be used in asynchronous contexts.
++
+The return type of an actor class, if specified, must be an `+async+` actor type.
+To support actor declaration, the top-level context of an interpreted program is an asynchronous context, allowing implicit and explicit `+await+` expressions.
++
+This change mostly affects interpreted programs and compiled programs with explicit actor class return types.
+
+* Strict checking of `+utf8+` strings for improved Candid compliance.
+
+* More liberal parsing of leb128-encoded numbers
+
+* New `+Random+` library added to `+motoko-base+`.
+
+* Candid includes the ability to extend function with optional parameters in a backward-compatible way.
+
+* Injecting a value into an option type (`+? <exp>+`) no longer requires heap allocation in most cases. This removes the memory-tax of using iterators.																													
 
 For information about breaking changes that were introduced in previous releases, see <<Breaking changes>>.
 
 For information about known issues that were introduced in previous releases, see <<Known issues and limitations>>.
+
+=== Highlights of what's new in 0.6.14
+
+The 0.6.14 release primarily includes internal enhancements and fixes and updates to the version of {proglang} and the {proglang} base library that are supported. 
+
+There are no user-visible new feature in this release. 
 
 === Highlights of what's new in 0.6.13
 
@@ -255,7 +353,7 @@ Without this fix, manually removing the directories the command is intended to d
 [[highlights]]
 === Highlights of what's new in 0.6.2
 
-The 0.6.2 release only included one important user-facing change which was also a breaking change that required you to update all existing projects.
+The 0.6.2 release only included one important user-facing change which was also a breaking change that requires you to update all existing projects.
 
 Starting with the 0.6.2 release, all canister identifiers are generated using a text-based representation.
 To work with the {release} release, therefore, you must update your projects to use the new canister identifier format.

--- a/modules/release-notes/pages/sdk-release-notes.adoc
+++ b/modules/release-notes/pages/sdk-release-notes.adoc
@@ -80,7 +80,7 @@ Key updates for {proglang} include support for the following features and change
 This change enables you to write expressions like this:
 +
 ....
-func foo(a : Nat) { return {x = x} }.									
+func foo(x : Nat) { return {x = x} }.
 ....
 +
 However, this new syntax breaks short-hand expressions such as:
@@ -96,10 +96,10 @@ For example, you might modify the expression to use an auxiliary declaration lik
 let a = 1; {a = a; b = a + 1}
 ....
 +
-Alternatively, you could modify the program to use object syntax like this:
+Alternatively, you could modify the program to use long form object syntax like this:
 +
 ....
-{public let a = 1; public let b = a + 1}
+object {public let a = 1; public let b = a + 1}
 ....
 
 * Free-standing blocks are no longer allowed.
@@ -124,7 +124,7 @@ This change mostly affects interpreted programs and compiled programs with expli
 
 * New `+Random+` library added to `+motoko-base+`.
 
-* Candid includes the ability to extend function with optional parameters in a backward-compatible way.
+* Candid includes the ability to extend records with optional fields in a backward-compatible way.
 
 * Injecting a value into an option type (`+? <exp>+`) no longer requires heap allocation in most cases. This removes the memory-tax of using iterators.
 


### PR DESCRIPTION
…base

**Overview**
I'd like some eyes on the DRAFT release notes  for 0.6.16 since it includes the 2MB limit and DER encoding and some Motoko change log stuff.

