### PR TITLE
Add Motoko Base as a separate entry

### DIFF
--- a/antora.yml
+++ b/antora.yml
@@ -9,7 +9,7 @@ nav:
   #- modules/languages/lang-overview-nav.adoc
   #- modules/candid-spec/candid-nav.adoc
   #- modules/language-guide/lang-nav.adoc
-  #- modules/base-libraries/lib-nav.adoc
+  - modules/base-libraries/lib-nav.adoc
   #- modules/rust-guide/rust-nav.adoc
   #- modules/integration/integration-nav.adoc
   #- modules/operators-guide/ops-nav.adoc


### PR DESCRIPTION
**Overview**
Call the lib-nav.adoc from the antora.yml file and remove it under the main ROOT navigation.