### PR TITLE
Fix broken links

### DIFF
--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -113,4 +113,4 @@
 ** xref:release-notes:0.6.22-rn.adoc[0.6.22]
 ** xref:release-notes:0.6.21-rn.adoc[0.6.21]
 ** xref:release-notes:0.6.20-rn.adoc[0.6.20]
-** link:https://github.com/dfinity/sdk/releases[Release history]
+** link:https://github.com/dfinity/docs/releases[Release history]

--- a/modules/ROOT/pages/videos-tutorials.adoc
+++ b/modules/ROOT/pages/videos-tutorials.adoc
@@ -156,7 +156,7 @@ video::G6vUrC9lues[youtube,width=100%,height=480px]
 This video segment summarizes the resources available and how you can get involved. 
 
 For further inspiration, check out the sample applications in the link:https://github.com/dfinity/examples[examples] or link:https://github.com/dfinity/awesome-dfinity[awesome-dfinity] repositories. 
-To be part of the conversation, join the  link:forum.dfinity.org[Developer Forum] or follow @dfinitydev on Twitter.
+To be part of the conversation, join the  link:https://forum.dfinity.org/[Developer Forum] or follow link:https://twitter.com/dfinitydev[@dfinitydev] on Twitter.
 
 ++++
 <h1></h1>
@@ -189,7 +189,7 @@ If you want more hands-on experience creating programs that run on the {IC}, che
 
 * link:developers-guide/tutorials/my-contacts{outfilesuffix}[Add a stylesheet]
 
-* link:xdevelopers-guide/tutorials/intercanister-calls{outfilesuffix}[Make inter-canister calls]
+* link:developers-guide/tutorials/intercanister-calls{outfilesuffix}[Make inter-canister calls]
 
 * link:developers-guide/tutorials/scalability-cancan{outfilesuffix}[Create scalable apps]
 

--- a/modules/developers-guide/pages/cli-reference/dfx-canister.adoc
+++ b/modules/developers-guide/pages/cli-reference/dfx-canister.adoc
@@ -417,7 +417,7 @@ You can set this value in the range of 0 to 256 TB.
 The default is 8GB.
 
 |`+-m+`, `+--mode <mode>+` |Specifies whether you want to `+install+`, `+reinstall+`, or `+upgrade+` canisters.
-For more information about installation modes and canister management, see link:working-with-canisters{outfilesuffix}[Managing canisters].
+For more information about installation modes and canister management, see link:../working-with-canisters{outfilesuffix}[Managing canisters].
 
 |===
 

--- a/modules/developers-guide/pages/concepts/canisters-code.adoc
+++ b/modules/developers-guide/pages/concepts/canisters-code.adoc
@@ -72,7 +72,7 @@ As a modern, high-level programming language, {proglang} provides some key featu
 * A sound type system that statically checks each program to ensure it can execute without type errors on all possible inputs.
 * Support for function abstractions, user-defined type definitions, and user-defined actors.
 
-For more detailed information about the {proglang} programming language itself, including syntactical conventions and supported features, see the link:../language-guide/motoko{outfilesuffix}[_Motoko Programming Language Guide_].
+For more detailed information about the {proglang} programming language itself, including syntactical conventions and supported features, see the link:../../language-guide/motoko{outfilesuffix}[_Motoko Programming Language Guide_].
 
 The following diagram provides a simplified drill-down view of the development environment as part of the {IC} ecosystem.
 
@@ -145,6 +145,6 @@ If you are looking for more information about canisters, check out the following
 
 * link:https://www.youtube.com/watch?v=LKpGuBOXxtQ[Introducing Canisters — An Evolution of Smart Contracts (video)]
 
-* link:https://www.youtube.com/watch?v=60uHQfoA8D[What is the DFINITY Canister SDK? (video)]
+* link:https://www.youtube.com/watch?v=60uHQfoA8Dk[What is the DFINITY Canister SDK? (video)]
 
-* link:https://www.youtube.com/watch?v=yqIoiyuG[Deploying your first application (video)]
+* link:https://www.youtube.com/watch?v=yqIoiyuGYNA[Deploying your first application (video)]

--- a/modules/developers-guide/pages/install-upgrade-remove.adoc
+++ b/modules/developers-guide/pages/install-upgrade-remove.adoc
@@ -102,7 +102,7 @@ If a newer version of `+dfx+` is available, the `+dfx upgrade+` command automati
 Note that you don't need to uninstall the software before installing the new version.
 However, if you want to perform a clean installation rather than an upgrade, you can first uninstall the software as described in xref:remove[Removing the software], then re-run the download and installation command.
 
-For information about the features and fixes in the latest release, see the link:sdk-release-notes{outfilesuffix}[Release notes].
+For information about the features and fixes in the latest release, see the link:../../release-notes/sdk-release-notes{outfilesuffix}[Release notes].
 
 [[remove]]
 == Removing the software

--- a/modules/developers-guide/pages/sample-apps.adoc
+++ b/modules/developers-guide/pages/sample-apps.adoc
@@ -39,12 +39,15 @@ For projects that use the {proglang} programming language, see link:https://gith
 * link:https://github.com/dfinity/examples/tree/master/motoko/counter[Counter]
 * link:https://github.com/dfinity/examples/tree/master/motoko/echo[Echo]
 * link:https://github.com/dfinity/examples/tree/master/motoko/factorial[Factorial]
-* link:https://github.com/dfinity/examples/tree/master/motoko/favorite_cities[Favorite cities]
+//* link:https://github.com/dfinity/examples/tree/master/motoko/favorite_cities[Favorite cities]
 * link:https://github.com/dfinity/examples/tree/master/motoko/hello-world[Hello, world]
 //* link:[Hex encoding and decoding]
 * link:https://github.com/dfinity/examples/tree/master/motoko/phone-book[Phone book]
 * link:https://github.com/dfinity/examples/tree/master/motoko/pub-sub[Publish/subscribe]
-* link:https://github.com/dfinity/examples/tree/master/motoko/simple_to_do[To-do checklist]
+* link:https://github.com/dfinity/examples/tree/master/motoko/quicksort[Quicksort]
+* link:https://github.com/dfinity/examples/tree/master/motoko/simple-to-do[To-do checklist]
+* link:https://github.com/dfinity/examples/tree/master/motoko/superheroes[Superheroes database]
+* link:https://github.com/dfinity/examples/tree/master/motoko/whoami[whoami]
 
 == Additional sample applications
 

--- a/modules/developers-guide/pages/tutorials/multiple-actors.adoc
+++ b/modules/developers-guide/pages/tutorials/multiple-actors.adoc
@@ -21,7 +21,7 @@ This project defines the following unrelated actors:
 
 * The `+assistant+` actor provides functions to add and show tasks in a to-do list.
 +
-For simplicity, the code sample for this tutorial only includes the functions to add to-do items and to show the current list of to-do items that have been added. A more complete version of this program-with additional functions for marking items as complete and removing items from the list—is available in the link:https://github.com/dfinity/examples/[examples] repository as link:https://github.com/dfinity/examples/tree/master/motoko/simple_to_do[Simple to-do checklist].
+For simplicity, the code sample for this tutorial only includes the functions to add to-do items and to show the current list of to-do items that have been added. A more complete version of this program-with additional functions for marking items as complete and removing items from the list—is available in the link:https://github.com/dfinity/examples/[examples] repository as link:https://github.com/dfinity/examples/tree/master/motoko/simple-to-do[Simple to-do checklist].
 
 * The `+rock_paper_scissors+` actor provides a function for determining a winner in a hard-coded rock-paper-scissors contest.
 +

--- a/modules/developers-guide/pages/work-with-languages.adoc
+++ b/modules/developers-guide/pages/work-with-languages.adoc
@@ -325,7 +325,7 @@ cp reverse.wasm build/reverse/
 
 In a standard development workflow, running the `+dfx build+` command creates several files in the `+canisters+` output directory, including one or more Candid interface description (`+.did+`) files that handle type matching for the data types associated with a program’s functions.
 
-For details about the syntax to use for different data types, see the link:../candid-spec/IDL{outfilesuffix}[Candid specification].
+For details about the syntax to use for different data types, see the link:https://github.com/dfinity/candid/tree/master/spec[Candid specification].
 
 To create a Candid interface description file for this program:
 

--- a/modules/languages/pages/languages-overview.adoc
+++ b/modules/languages/pages/languages-overview.adoc
@@ -13,7 +13,7 @@ The Languages and API reference information is intended for advanced programmers
 
 * link:../candid-guide/candid-intro{outfilesuffix}[Candid Guide]
 * link:https://github.com/dfinity/candid/tree/master/spec[Candid specification]
-* link:../https://docs.rs/candid[Candid crate]
+* link:https://docs.rs/candid[Candid crate]
 
 ////
 == JavaScript

--- a/modules/quickstart/pages/newcomers.adoc
+++ b/modules/quickstart/pages/newcomers.adoc
@@ -23,7 +23,7 @@ The steps in this section describe how to prepare a basic development environmen
 [[open-terminal]]
 == Open a terminal
 
-You need to know how to open a terminal and navigate to directories to install the {sdk-short-name} and to start and stop the {IC} running locally when trying any of the link:../developers-guide/tutorial-intro{outfilesuffix}[tutorials].
+You need to know how to open a terminal and navigate to directories to install the {sdk-short-name} and to start and stop the {IC} running locally when trying any of the link:../developers-guide/tutorials-intro{outfilesuffix}[tutorials].
 
 To open the Terminal application on macOS:
 
@@ -95,7 +95,7 @@ By default, a new terminal shell always opens in your home directory with a path
 To keep your workspace tidy, you can create a separate folder for your {IC} projects.
 
 Creating a working folder for {IC} projects is optional, but can make it easier to find and navigate between projects.
-A separate folder is especially useful if you plan to experiment with any of the link:../developers-guide/tutorial-intro{outfilesuffix}[tutorials] beyond the link:quickstart-intro{outfilesuffix}[Quick start].
+A separate folder is especially useful if you plan to experiment with any of the link:../developers-guide/tutorials-intro{outfilesuffix}[tutorials] beyond the link:quickstart-intro{outfilesuffix}[Quick start].
 
 To create a new working folder:
 

--- a/modules/quickstart/pages/quickstart-intro.adoc
+++ b/modules/quickstart/pages/quickstart-intro.adoc
@@ -30,6 +30,6 @@ The default application consists of back-end code written in  {proglang}, a prog
 
 If you are looking for more information before getting started or want to view a demonstration of how to deploy before you try it for yourself, check out the following related resources:
 
-* link:https://www.youtube.com/watch?v=jduSMHxdYD8&[Building on the Internet Computer: Fundamentals (video)]
-* link:https://www.youtube.com/watch?v=60uHQfoA8Dk&[What is the DFINITY Canister SDK (video)]
-* link:https://www.youtube.com/watch?v=yqIoiyuGYNA&l[Deploying your first application (video)]
+* link:https://www.youtube.com/watch?v=jduSMHxdYD8[Building on the Internet Computer: Fundamentals (video)]
+* link:https://www.youtube.com/watch?v=60uHQfoA8Dk[What is the DFINITY Canister SDK (video)]
+* link:https://www.youtube.com/watch?v=yqIoiyuGYNA[Deploying your first application (video)]

--- a/modules/release-notes/pages/0.6.22-rn.adoc
+++ b/modules/release-notes/pages/0.6.22-rn.adoc
@@ -42,7 +42,7 @@ All of Motoko sample apps in the link:https://github.com/dfinity/examples/tree/m
 +
 There are also new sample apps to illustrate using arrays (link:https://github.com/dfinity/examples/tree/master/motoko/quicksort[Quicksort]) and building create/read/update/delete (CRUD) operations for a web application link:https://github.com/dfinity/examples/tree/master/motoko/superheroes[Superheroes].
 
-* The link:https://github.com/dfinity/linkedup:[LinkedUp] sample application has been updated to work with the latest release of Motoko and the SDK.
+* The link:https://github.com/dfinity/linkedup[LinkedUp] sample application has been updated to work with the latest release of Motoko and the SDK.
 
 === Candid
 

--- a/modules/release-notes/pages/sdk-release-notes.adoc
+++ b/modules/release-notes/pages/sdk-release-notes.adoc
@@ -39,7 +39,7 @@ The errors and warnings issued by the `+npm+` package manager do not prevent you
 
 == Additional questions and feedback
 
-Joining the link:forum.dfinity.org[DFINITY Developer Forum] is an effective way to learn from community members, ask questions, solicit help from other developers, and provide insight and feedback about your experiences.
+Joining the link:https://forum.dfinity.org/[DFINITY Developer Forum] is an effective way to learn from community members, ask questions, solicit help from other developers, and provide insight and feedback about your experiences.
 
 If you have questions that aren't answered by the community, you might also want to check out link:../developers-guide/troubleshooting{outfilesuffix}[Troubleshooting] topics for information about common issues, workarounds for known issues, or help troubleshooting warnings or errors.
 


### PR DESCRIPTION
Encountered a broken link while reading documentation, decided to run the docs website through https://www.deadlinkchecker.com/website-dead-link-checker.asp and fix what I can.

There's still some broken links in the Motoko Language Guide and the Rust guide, but I don't think those repositories are publicly visible.