### PR TITLE
Update the first two steps, add disclaimer for 0.7.0-beta releases

### DIFF
--- a/modules/developers-guide/examples/candid-ui.adoc
+++ b/modules/developers-guide/examples/candid-ui.adoc
@@ -6,9 +6,12 @@ The language provides a unified way of interacting with canisters in various lan
 
 Based on the type signature of the actor, Candid provides a web interface that allows you to call canister functions for testing and debugging.
 
+NOTE: If you have upgraded to a `0.7.0-beta` version of the {sdk-short-name}, you cannot yet use the Candid web interface to test functions in a browser. To use the Candid web interface, you can install a previous version of the {sdk-short-name} for your project. 
+
 To use the Candid web interface to test canister functions:
 
-. Deploy your project using the `+dfx canister install+` command and copy the canister identifier associated with the main actor for your application.
+. Deploy your project using the `+dfx deploy+` or `+dfx canister install+` command.
+. Copy the canister identifier associated with the *main actor* for your application.
 . Open a browser and navigate to the address and port number specified in the `+dfx.json+` configuration file.
 +
 By default, the `+local+` network binds to the `+127.0.0.1:8000+` address and port number.


### PR DESCRIPTION
**Overview**
Adding a disclaimer in case we update the website with docs before we make 0.7.0 "latest" (especially since we are actively promoting the newer version in the forum).
