### PR TITLE
Add default wallet section to the navigation

### DIFF
--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -24,6 +24,7 @@
 //*** xref:developers-guide:basic-syntax-rules.adoc[C and C++]
 ** xref:developers-guide:webpack-config.adoc[Add frontend assets]
 ** xref:developers-guide:working-with-canisters.adoc[Manage canisters]
+** xref:developers-guide:default-wallet.adoc[Use the default cycles wallet]
 ** xref:developers-guide:troubleshooting.adoc[Troubleshoot issues]
 
 .xref:developers-guide:tutorials-intro.adoc[Tutorials]


### PR DESCRIPTION
**Overview**
Some cycles wallet methods are only exposed on the command-line. This section provides basic documentation for using the methods with command-line examples. This PR exposes the section in the main navigation.