### PR TITLE
Add IDP service link to navigation

### DIFF
--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -92,6 +92,7 @@
 ////
 
 .Integration
+** xref:ic-identity-guide:what-is-ic-identity.adoc[Authenticating using internet identity service]
 ** xref:integration:ledger-quick-start.adoc[Integrating with the Ledger]
 //** xref:integration:nns-quick-start.adoc[Integrating with NNS]
 


### PR DESCRIPTION
**Overview**
Need to include user and developer-facing documentation in the SDK website. This PR adds an entry point in the main navigation.