### PR TITLE
fix: Remove rogue H2

### DIFF
--- a/modules/ROOT/pages/index.adoc
+++ b/modules/ROOT/pages/index.adoc
@@ -11,7 +11,6 @@
 
     <div class="landing-hero">
         <h1>We are on a mission to reinvent the internet and bring it back to its truly open roots</h1>
-        <h2>Join us in building the future of the internet</h2>
         <div class="landing-cta">
         <p>To download the DFINITY Canister SDK, run the following command in your terminal.</p>
 ++++
@@ -73,7 +72,7 @@ sh -ci "$(curl -fsSL https://sdk.dfinity.org/install.sh)"
     <div class="landing-pitch">
         <a href="https://sdk.dfinity.org/docs/language-guide/motoko.html"><img src="_images/MotokoLogo2.png" height="320" width="320" /></a>
         <h2>Motoko — Build on the Internet Computer in Expert Mode</h2>
-        <p>The <b>Motoko</b> language is optimized for authoring for the Internet Computer.</p>     
+        <p>The <b>Motoko</b> language is optimized for authoring for the Internet Computer.</p>
         <p>It is so packed with familiar features — like async/await, randomness, time, and even infinite (arbitrary) precision — that you might just forget you're building directly on a new kind of blockchain computer.</p>
         <p class="link"><a href="language-guide/motoko.html">Explore the Motoko Programming Language</a></p>
     </div>


### PR DESCRIPTION
This little guy was floating unstyled all by himself. Let's remove him for now so we can set him up for success in the future.