### PR TITLE
Fix link to NNS app

### DIFF
--- a/modules/quickstart/pages/quickstart-intro.adoc
+++ b/modules/quickstart/pages/quickstart-intro.adoc
@@ -33,7 +33,7 @@ The default application consists of back-end code written in  {proglang}, a prog
 As discussed in link:concepts/tokens-cycles{outfilesuffix}[Tokens and cycles], *cycles* are required to power canister operations for applications running on the {IC}. 
 As a developer, you have a few different options for acquiring and managing cycles for your applications:
 
-* Purchase or claim ICP tokens through an exchange that lists ICP tokens available for trade, then convert your tokens to cycles using the link:network-quickstart{outfilesuffix}#convert-tokens[{sdk-short-name} command-line interface] or the link:nns-app{outfilesuffix}[Network Nervous System application].
+* Purchase or claim ICP tokens through an exchange that lists ICP tokens available for trade, then convert your tokens to cycles using the link:network-quickstart{outfilesuffix}#convert-tokens[{sdk-short-name} command-line interface] or the link:https://nns.ic0/app[Network Nervous System application].
 * Register for cycles by signing up for an account or link:../developers-guide/default-wallet{outfilesuffix}#wallet-create-wallets[cycles wallet] through a provider offering those services.
 * Coordinate with other developers to link:../developers-guide/default-wallet{outfilesuffix}#wallet-send[send] and link:../developers-guide/default-wallet{outfilesuffix}#wallet-receive[receive] cycles directly to and from canisters through a cycles wallet or another application.
 


### PR DESCRIPTION
**Overview**
Replace the placeholder link with a link to the NNS app itself.