### PR TITLE
Improve seed donor instructions

### DIFF
--- a/modules/token-holders/pages/seed-donations.adoc
+++ b/modules/token-holders/pages/seed-donations.adoc
@@ -182,10 +182,6 @@ Once you have installed Keysmith and the DFINITY Canister SDK, and you are [.und
 For the duration of your session, you store your seed phrase in an environment variable.
 It will be eliminated from your system when you turn your computer off.
 
-Check your balance (optional)
-
-Enter your seed phrase.
-
 [source,bash]
 ----
 read seed
@@ -213,9 +209,9 @@ echo $seed | keysmith legacy-address -f -
 
 The output is a 40 character hex string. It looks something like this:
 
-...
+....
 2d89d96b10f7a9456a9154b2f5309ee70df5bce1
-...
+....
 
 You can check your ICPT balance as follows:
 
@@ -257,13 +253,26 @@ dfx identity import <name> identity.pem
 rm -P identity.pem
 ----
 
-Here, <name> is an alias that you can choose arbitrarily for your identity, e.g. "jane" or "id-0", "id-1", "id-2", ...
+Here, <name> is an alias that you can choose arbitrarily for your identity, e.g. "jane".
 
 The command above displays output similar to the following:
 
 ....
 Creating identity: "jane".
 Created identity: "jane".
+....
+
+Make your new identity the currently-active one.
+
+[source,bash]
+----
+dfx identity use <name>
+----
+
+The command above displays output similar to the following:
+
+....
+Using identity: "jane".
 ....
 
 If you are an early contributor, then you may have more than one key derived from your one seed.
@@ -279,25 +288,18 @@ rm -P identity-*.pem
 ----
 
 Then repeat the above with all four occurences of `0` replaced by `1`, then by `2`, etc.
-
-Set a new currently-active identity.
-
-[source,bash]
-----
-dfx identity use <name>
-----
-
-The command above displays output similar to the following:
-
-....
-Using identity: "jane".
-....
-
-You can list all available identities with
+After this, you can list all available identities with
 
 [source,bash]
 ----
 dfx identity list
+----
+
+Choose one, for example
+
+[source,bash]
+----
+dfx identity use jane0
 ----
 
 == Take control of your neurons

--- a/modules/token-holders/pages/seed-donations.adoc
+++ b/modules/token-holders/pages/seed-donations.adoc
@@ -229,11 +229,13 @@ Each time you repeat you have to specify the key number (also called "index") wi
 [source,bash]
 ----
 echo $seed | keysmith private-key -f - -i 0 -o identity-0.pem
-dfx identity import <name> identity-0.pem
+dfx identity import jane0 identity-0.pem
 rm -P identity-*.pem
 ----
 
-Make the new identity your currently-active identity.
+Then repeat the above with all four occurences of `0` replaced by `1`, then by `2`, etc.
+
+Set a new currently-active identity.
 
 [source,bash]
 ----

--- a/modules/token-holders/pages/seed-donations.adoc
+++ b/modules/token-holders/pages/seed-donations.adoc
@@ -217,6 +217,7 @@ You can check your ICPT balance as follows:
 
 [source,bash]
 ----
+echo {} > dfx.json
 GTC=renrk-eyaaa-aaaaa-aaada-cai
 ADDR=$(echo $seed | keysmith legacy-address -f -)
 dfx canister --network=https://ic0.app --no-wallet call $GTC balance '("'$ADDR'")'
@@ -250,7 +251,7 @@ Import your private key(s) into the DFINITY Canister SDK and then remove it from
 [source,bash]
 ----
 dfx identity import <name> identity.pem
-rm -P identity.pem
+rm identity.pem
 ----
 
 Here, <name> is an alias that you can choose arbitrarily for your identity, e.g. "jane".
@@ -284,7 +285,7 @@ Each time you repeat you have to specify the key number (also called "index") wi
 ----
 echo $seed | keysmith private-key -f - -i 0 -o identity.pem
 dfx identity import jane0 identity.pem
-rm -P identity.pem
+rm identity.pem
 ----
 
 Then repeat the above with index 1, i.e. `-i 1` instead of `-i 0` and `jane1` instead of `jane0`, index 2, etc.

--- a/modules/token-holders/pages/seed-donations.adoc
+++ b/modules/token-holders/pages/seed-donations.adoc
@@ -282,12 +282,12 @@ Each time you repeat you have to specify the key number (also called "index") wi
 
 [source,bash]
 ----
-echo $seed | keysmith private-key -f - -i 0 -o identity-0.pem
-dfx identity import jane0 identity-0.pem
-rm -P identity-*.pem
+echo $seed | keysmith private-key -f - -i 0 -o identity.pem
+dfx identity import jane0 identity.pem
+rm -P identity.pem
 ----
 
-Then repeat the above with all four occurences of `0` replaced by `1`, then by `2`, etc.
+Then repeat the above with index 1, i.e. `-i 1` instead of `-i 0` and `jane1` instead of `jane0`, index 2, etc.
 After this, you can list all available identities with
 
 [source,bash]
@@ -356,7 +356,7 @@ Derive your public key. If you are an early contributor, then be sure to specify
 
 [source,bash]
 ----
-PUBLIC_KEY="$(echo $seed | keysmith public-key -f - -i 0)"
+PUBLIC_KEY="$(echo $seed | keysmith public-key -f -)"
 ----
 
 Call the Genesis Token Canister to claim your neurons.
@@ -376,7 +376,7 @@ Derive your public key. If you are an early contributor, then be sure to specify
 
 [source,bash]
 ----
-PUBLIC_KEY="$(echo $seed | keysmith public-key -f - -i 0)"
+PUBLIC_KEY="$(echo $seed | keysmith public-key -f -)"
 ----
 
 Sign a message to claim your neurons.

--- a/modules/token-holders/pages/seed-donations.adoc
+++ b/modules/token-holders/pages/seed-donations.adoc
@@ -200,7 +200,7 @@ Derive your private key from your seed phrase. If you are an early contributor, 
 
 [source,bash]
 ----
-echo $seed | ./keysmith private-key -f - -i 0 -o identity-0.pem
+echo $seed | keysmith private-key -f - -i 0 -o identity-0.pem
 ----
 
 Import your private key(s) into the DFINITY Canister SDK.

--- a/modules/token-holders/pages/seed-donations.adoc
+++ b/modules/token-holders/pages/seed-donations.adoc
@@ -200,6 +200,45 @@ If you prefer to not have your seed phrase displayed as you type then use this c
 read -s seed
 ----
 
+=== Check your legacy address and balance (optional)
+
+At this point you can already verify your legacy address and ICPT balance.
+The legacy address matches to what was formerly called "DFN address" in the Dfinity Chrome extension.
+You may have copied it from the Chrome extension for your records back when you used the extension.
+
+[source,bash]
+----
+echo $seed | keysmith legacy-address -f -
+----
+
+The output is a 40 character hex string. It looks something like this:
+
+...
+2d89d96b10f7a9456a9154b2f5309ee70df5bce1
+...
+
+You can check your ICPT balance as follows:
+
+[source,bash]
+----
+GTC=renrk-eyaaa-aaaaa-aaada-cai
+ADDR=$(echo $seed | keysmith legacy-address -f -)
+dfx canister --network=https://ic0.app --no-wallet call $GTC balance '("'$ADDR'")'
+----
+
+The output is the number of ICPT associated with your address.
+
+If you are an early contributor then you may have multiple addresses, all derived from your one seed phrase. To check the balance in each of them you do the following commands:
+
+[source,bash]
+----
+GTC=renrk-eyaaa-aaaaa-aaada-cai
+ADDR=$(echo $seed | keysmith legacy-address -f - -i 0)
+dfx canister --network=https://ic0.app --no-wallet call $GTC balance '("'$ADDR'")'
+----
+
+Then you repeat the last two lines with `-i 1`, `-i 2`, etc.
+
 === Derive and import your private key
 
 Derive your private key from your seed phrase.

--- a/modules/token-holders/pages/seed-donations.adoc
+++ b/modules/token-holders/pages/seed-donations.adoc
@@ -204,11 +204,12 @@ echo $seed | keysmith private-key -f -
 ----
 
 This creates a file `identity.pem` containing your private key.
-Import your private key(s) into the DFINITY Canister SDK.
+Import your private key(s) into the DFINITY Canister SDK and then remove it from the filesystem.
 
 [source,bash]
 ----
 dfx identity import <name> identity.pem
+rm -P identity.pem
 ----
 
 Here, <name> is an alias that you can choose arbitrarily for your identity, e.g. "jane" or "id-0", "id-1", "id-2", ...
@@ -229,6 +230,7 @@ Each time you repeat you have to specify the key number (also called "index") wi
 ----
 echo $seed | keysmith private-key -f - -i 0 -o identity-0.pem
 dfx identity import <name> identity-0.pem
+rm -P identity-*.pem
 ----
 
 Make the new identity your currently-active identity.

--- a/modules/token-holders/pages/seed-donations.adoc
+++ b/modules/token-holders/pages/seed-donations.adoc
@@ -176,9 +176,13 @@ DFX_VERSION=0.7.0-beta.8 sh -ci "$(curl -fsSL https://sdk.dfinity.org/install.sh
 
 *Warning: Note that `dfx` will currently not install on M1-based Macs.*
 
-=== Derive and import your private key
+=== Set your seed phrase for use with keysmith
 
-Once you have installed Keysmith and the DFINITY Canister SDK, and you are [.underline]#confident that your environment is secure#, then you are ready to derive and import your private key.
+Once you have installed Keysmith and the DFINITY Canister SDK, and you are [.underline]#confident that your environment is secure#, then you are ready to enter your seed for use with `keysmith`.
+For the duration of your session, you store your seed phrase in an environment variable.
+It will be eliminated from your system when you turn your computer off.
+
+Check your balance (optional)
 
 Enter your seed phrase.
 
@@ -195,6 +199,8 @@ If you prefer to not have your seed phrase displayed as you type then use this c
 ----
 read -s seed
 ----
+
+=== Derive and import your private key
 
 Derive your private key from your seed phrase.
 

--- a/modules/token-holders/pages/seed-donations.adoc
+++ b/modules/token-holders/pages/seed-donations.adoc
@@ -196,18 +196,19 @@ If you prefer to not have your seed phrase displayed as you type then use this c
 read -s seed
 ----
 
-Derive your private key from your seed phrase. If you are an early contributor, then you will need to derive multiple private keys; one for each derivation index. Use the `-i` flag to specify which private key you want to derive. If you are a seed round donor, then you only have one private key at derivation index `0`.
+Derive your private key from your seed phrase.
 
 [source,bash]
 ----
-echo $seed | keysmith private-key -f - -i 0 -o identity-0.pem
+echo $seed | keysmith private-key -f -
 ----
 
+This creates a file `identity.pem` containing your private key.
 Import your private key(s) into the DFINITY Canister SDK.
 
 [source,bash]
 ----
-dfx identity import <name> identity-0.pem
+dfx identity import <name> identity.pem
 ----
 
 Here, <name> is an alias that you can choose arbitrarily for your identity, e.g. "jane" or "id-0", "id-1", "id-2", ...
@@ -219,7 +220,18 @@ Creating identity: "jane".
 Created identity: "jane".
 ....
 
-Make this identity your currently-active identity.
+If you are an early contributor, then you may have more than one key derived from your one seed.
+You should import all of them for use with dfx.
+To do that you will have to repeat the two commands above for each key.
+Each time you repeat you have to specify the key number (also called "index") with the `-i` option to `keysmith` as follows.
+
+[source,bash]
+----
+echo $seed | keysmith private-key -f - -i 0 -o identity-0.pem
+dfx identity import <name> identity-0.pem
+----
+
+Make the new identity your currently-active identity.
 
 [source,bash]
 ----
@@ -231,6 +243,13 @@ The command above displays output similar to the following:
 ....
 Using identity: "jane".
 ....
+
+You can list all available identities with
+
+[source,bash]
+----
+dfx identity list
+----
 
 == Take control of your neurons
 


### PR DESCRIPTION
A couple of improvements including an early balance check, better separation of default explanation for seed donors from special instructions for early contributors who need to specify a derivation index.