### PR TITLE
Change from SSH to HTTPS in clone command

### DIFF
--- a/modules/developers-guide/pages/tutorials/intercanister-calls.adoc
+++ b/modules/developers-guide/pages/tutorials/intercanister-calls.adoc
@@ -42,7 +42,7 @@ To experiment with inter-canister calls using the LinkedUp sample application:
 +
 [source,bash]
 ----
-git clone git@github.com:dfinity/linkedup.git
+git clone https://github.com/dfinity/linkedup.git
 ----
 . Change to the local working directory for the `linkedup` repository.
 +


### PR DESCRIPTION
**Overview**
Per support ticket, seems like this link might be better than the SSH one.