### PR TITLE
Advertise using the `--background` flag

### DIFF
--- a/modules/developers-guide/pages/tutorials/explore-templates.adoc
+++ b/modules/developers-guide/pages/tutorials/explore-templates.adoc
@@ -200,7 +200,7 @@ To start the network locally:
 +
 [source,bash]
 ----
-dfx start
+dfx start --background
 ----
 +
 Depending on your platform and local security settings, you might see a warning displayed.


### PR DESCRIPTION
to `dfx start`

**Overview**
Why do we need this feature? What are we trying to accomplish?

A Linux person will know how to use the shell (appending `&` or using `CTRL+Z` and `bg`), but this should work on all platforms.

**Requirements**
What requirements are necessary to consider this problem solved?

**Considered Solutions**
What solutions were considered?

**Recommended Solution**
What solution are you recommending? Why?

**Considerations**
What impact will this change have on security, performance, users (e.g. breaking changes) or the team (e.g. maintenance costs)?
