### PR TITLE
Change the version label from master to latest

### DIFF
--- a/antora.yml
+++ b/antora.yml
@@ -1,6 +1,6 @@
 name: docs
 title: Developer Center
-version: 'master'
+version: 'latest'
 start_page: ROOT:index.adoc
 nav:
   - modules/ROOT/nav.adoc


### PR DESCRIPTION
**Overview**
To be more PC and "accurate" changing the label for the docs bucket from "master" to "latest"

**Recommended Solution**
What solution are you recommending? Why?

**Considerations**
What impact will this change have on security, performance, users (e.g. breaking changes) or the team (e.g. maintenance costs)?
