### PR TITLE
Clarify --host in dfx start

### DIFF
--- a/modules/developers-guide/pages/cli-reference/dfx-start.adoc
+++ b/modules/developers-guide/pages/cli-reference/dfx-start.adoc
@@ -38,7 +38,7 @@ You can use the following option with the `+dfx start+` command.
 [width="100%",cols="<32%,<68%",options="header",]
 |===
 |Option |Description
-|`+--host host+` |Specifies the host name and port number to bind the frontend to.
+|`+--host host+` |Specifies the host interface IP address and port number to bind the frontend to. The default is `127.0.0.1:8000`.
 |===
 
 == Examples


### PR DESCRIPTION
I attempted to run `dfx` on a headless server I'm ssh'd in to from a laptop, and it took me a moment to figure out how to use `dfx start --host`, because the documentation says _host name_ but it doesn't actually accept a _host name_, perhaps we could clarify it like this?

BTW where is the source code of the `dfx` tool, so that I can raise a similar PR for this there?