### PR TITLE
Add JS redirect from index page to dfinity.org/developers

### DIFF
--- a/modules/ROOT/pages/index.adoc
+++ b/modules/ROOT/pages/index.adoc
@@ -1,4 +1,4 @@
-= Write code for the {IC}
+= Developer Center | DFINITY
 :idprefix:
 :idseparator: -
 :!example-caption:

--- a/modules/ROOT/pages/index.adoc
+++ b/modules/ROOT/pages/index.adoc
@@ -6,11 +6,15 @@
 :page-layout: landing
 
 ++++
+<script>
+// Simulate HTTP Redirect to marketing /developers site
+window.location.replace("https://dfinity.org/developers");
+</script>
+++++
+
+++++
 <div class="html-container">
    <div class="landing-hero">
-     <div class="dev">
-     <a href=https://dfinity.org/developers>Developers</a>
-     </div>
         <h1>Build applications on-chain using smart contracts.</h1>
         <div class="landing-cta">
         <p>To download the Internet Computer SDK, run the following command in your terminal.</p>


### PR DESCRIPTION
**Overview**

Why do we need this feature? What are we trying to accomplish?

Redirect visitors to the index page to the (new) primary developer landing page https://dfinity.org/developers/

**Requirements**

* don't have two dev landing pages
* allow the desired teams to experimentally optimize the dev landing page

**Considered Solutions**

* other forms of redirect: e.g. via cloud providers

**Recommended Solution**

* Use a JS redirect on the index page. This kind of redirect will simulate an HTTP redirect such that the actual index page never appears in the browser's history. It's as if any link to the `/docs/index.html` page was actually to `dfinity.org/developers`
* Change the page title of the index page to be the same as dfinity.org/developers so the redirect is even less noticeable in browser UI

**Considerations**
What impact will this change have on security, performance, users (e.g. breaking changes) or the team (e.g. maintenance costs)?

* minimal impact, easily reversible if further experiments desire it