### PR TITLE
feat: dfx canister create controller parameter is now a named parameter

### DIFF
--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -12,6 +12,7 @@
 *** Introducing the SDK
 **** xref:developers-guide:install-upgrade-remove.adoc[Install, upgrade, or remove software]
 **** xref:release-notes:sdk-release-notes.adoc[Release notes]
+***** xref:release-notes:0.8.1-rn.adoc[0.8.2]
 ***** xref:release-notes:0.8.1-rn.adoc[0.8.1]
 ***** xref:release-notes:0.8.0-rn.adoc[0.8.0]
 ***** xref:release-notes:0.7.7-rn.adoc[0.7.7]

--- a/modules/release-notes/pages/0.8.2-rn.adoc
+++ b/modules/release-notes/pages/0.8.2-rn.adoc
@@ -1,0 +1,22 @@
+= Highlights of what's new in {release}
+:description: DFINITY Canister Software Development Kit Release Notes
+:proglang: Motoko
+:IC: Internet Computer
+:company-id: DFINITY
+:release: 0.8.2
+ifdef::env-github,env-browser[:outfilesuffix:.adoc]
+
+An overview of the {release} release:
+
+- Breaking change in how to specify a controller to `dfx canister create`
+
+== Changes to DFX
+
+=== Breaking change: controller parameter for dfx canister create
+
+Breaking change: The controller parameter for `dfx canister create` is now passed as a named parameter,
+rather than optionally following the canister name.
+
+Old: dfx canister create [canister name] [controller]
+New: dfx canister create --controller <controller> [canister name]
+


### PR DESCRIPTION
**Overview**
Release notes for the next version of dfx: `dfx canister create --controller <controller> ...`