### PR TITLE
frontend docs refresh

### DIFF
--- a/modules/developers-guide/examples/add-stylesheet-package.json
+++ b/modules/developers-guide/examples/add-stylesheet-package.json
@@ -23,9 +23,9 @@
     "webpack": "5.24.4"
   },
   "dependencies": {
-    "@dfinity/agent": "0.9.2",
-    "@dfinity/candid": "0.9.2",
-    "@dfinity/principal": "0.9.2",
+    "@dfinity/agent": "0.10.0",
+    "@dfinity/candid": "0.10.0",
+    "@dfinity/principal": "0.10.0",
     "react-dom": "^17.0.2",
     "react": "^17.0.2"
   }

--- a/modules/developers-guide/examples/custom-frontend-package.json
+++ b/modules/developers-guide/examples/custom-frontend-package.json
@@ -16,9 +16,9 @@
     "copy:types": "rsync -avr .dfx/$(echo ${DFX_NETWORK:-'**'})/canisters/** --exclude='assets/' --exclude='idl/' --exclude='*.wasm' --delete src/declarations"
   },
   "devDependencies": {
-    "@dfinity/agent": "0.9.2",
-    "@dfinity/candid": "0.9.2",
-    "@dfinity/principal": "0.9.2",
+    "@dfinity/agent": "0.10.0",
+    "@dfinity/candid": "0.10.0",
+    "@dfinity/principal": "0.10.0",
     "assert": "2.0.0",
     "buffer": "6.0.3",
     "copy-webpack-plugin": "^9.0.1",

--- a/modules/developers-guide/examples/mycontacts/mod-index.jsx
+++ b/modules/developers-guide/examples/mycontacts/mod-index.jsx
@@ -1,6 +1,7 @@
 import * as React from "react";
 import { render } from "react-dom";
 import { contacts } from "../../declarations/contacts";
+import "../assets/mycontacts.css";
 
 const Contact = () => {
   async function doInsert() {

--- a/modules/developers-guide/pages/tutorials/custom-frontend.adoc
+++ b/modules/developers-guide/pages/tutorials/custom-frontend.adoc
@@ -260,7 +260,7 @@ To start the environment locally:
 dfx start --background
 ----
 +
-After the local {IC} environment completes its startup operations, you can continue to the next step.
+After the local canister execution environment completes its startup operations, you can continue to the next step.
 
 == Register, build, and deploy the dapp
 

--- a/modules/developers-guide/pages/tutorials/custom-frontend.adoc
+++ b/modules/developers-guide/pages/tutorials/custom-frontend.adoc
@@ -264,7 +264,7 @@ After the local {IC} environment completes its startup operations, you can conti
 
 == Register, build, and deploy the dapp
 
-After you connect to the local {IC} execution environment, you can register, build, and deploy your dapp locally.
+After you connect to the local canister execution environment, you can register, build, and deploy your dapp locally.
 
 To deploy the dapp locally:
 

--- a/modules/developers-guide/pages/tutorials/custom-frontend.adoc
+++ b/modules/developers-guide/pages/tutorials/custom-frontend.adoc
@@ -336,7 +336,7 @@ To stop the local network:
 
 . In the terminal that displays network operations, press Control-C to interrupt the local network process.
 
-. Stop the {IC} environment by running the following command:
+. Stop the local canister execution environment by running the following command:
 +
 [source,bash]
 ----

--- a/modules/developers-guide/pages/tutorials/custom-frontend.adoc
+++ b/modules/developers-guide/pages/tutorials/custom-frontend.adoc
@@ -4,12 +4,12 @@ ifdef::env-github,env-browser[:outfilesuffix:.adoc]
 :IC: Internet Computer
 :company-id: DFINITY
 
-Now that you have a basic understanding of how to create, build, and deploy a simple program and are familiar with the default project files and sample front-end, you might want to start experimenting with different ways to customize the front-end user experience for your project.
+Now that you have a basic understanding of how to create, build, and deploy a simple dapp and are familiar with the default project files and sample front-end, you might want to start experimenting with different ways to customize the front-end user experience for your project.
 
-This tutorial illustrates using a simple React framework to create a new front-end for the default sample program and guides you through some basic modifications to customize the interface displayed.
+This tutorial illustrates using the React framework to create a new front-end for the default sample dapp and guides you through some basic modifications to customize the interface displayed.
 Later tutorials expand on the techniques introduced here, but if you already know how to use CSS, HTML, JavaScript, and React or other frameworks to build your user interface, you can skip this tutorial.
 
-NOTE: This tutorial illustrates using the React framework to manage the Document Object Model (DOM) for your canister.
+NOTE: This tutorial illustrates using the React framework to manage the Document Object Model (DOM) for your canister smart contract.
 Because React has its own custom DOM syntax, you need to modify the webpack configuration to compile the front-end code, which is written in JSX. For more information about learning to use React and JSX, see link:https://reactjs.org/docs/getting-started.html[Getting started] on the https://reactjs.org/[React website].
 
 == Before you begin
@@ -23,16 +23,16 @@ For information about installing node for your local operating system and packag
 
 * You have installed the Visual Studio Code plugin for {proglang} as described in link:../../quickstart/local-quickstart{outfilesuffix}#install-vscode[Install the language editor plug-in] if you are using Visual Studio Code as your IDE.
 
-* You have stopped any {IC} network processes running on the local
+* You have stopped any {sdk-short-name} processes running on the local
 computer.
 
-NOTE: Because of significant changes to the handling of HTTP requests and front-end assets, this tutorial requires you to use the {sdk-short-name} version `+0.7.0+` or later. For an overview of what's changed, see this link:../../http-middleware{outfilesuffix}[article].
+NOTE: This tutorial requires you to use the {sdk-short-name} version `+0.8.0+` or later.
 
 This tutorial takes approximately 30 minutes to complete.
 
 == Create a new project
 
-To create a new project directory for your custom front-end application:
+To create a new project directory for your custom front-end dapp:
 
 [arabic]
 . Open a terminal shell on your local computer, if you don’t already have one open.
@@ -125,14 +125,14 @@ Let's take a look at the settings in this section.
 
 * The assets canister has a default dependency on the main canister for the project.
 
-* The `+frontend.entrypoint+` setting specifies the path to a file—in this case, the `+index.html+` file—to use as your application entry point.
+* The `+frontend.entrypoint+` setting specifies the path to a file—in this case, the `+index.html+` file—to use as your dapp entry point.
 If you had a different starting point—for example, a custom `first-page.html` file—you would modify this setting.
 
 * The `+source+` settings specify the path to your `src` and `dist` directories. The `src` setting specifies the directory to use for static assets that will be included in your assets canister when you build your project.
 If you have custom cascading stylesheet (CSS) or JavaScript files, you would include them in the folder specified by this path.
 After building the project, the project assets are served from the directory specified by the `+dist+` setting.
 
-* The `+type+` setting specifies that the `+custom_greeting_assets+` is an asset canister rather than a program canister.
+* The `+type+` setting specifies that the `+custom_greeting_assets+` should use the https://github.com/dfinity/certified-assets[certified asset canister], which comes with everything you need to host static assets on the {platform}.
 --
 +
 For this tutorial, we are going to add React JavaScript in an `+index.jsx+` file, but that won't require any changes to the default settings in the `dfx.json` file.
@@ -140,14 +140,14 @@ For this tutorial, we are going to add React JavaScript in an `+index.jsx+` file
 
 == Review the default front-end files
 
-For this tutorial, you are going to use the default `+main.mo+` program and only manipulate the application by modifying the front-end.
+For this tutorial, you are going to make calls to the default `+main.mo+` canister through a custom front-end.
 Before you make any changes, though, let's take a look at what's in the default front-end files for a project.
 
 To review the default front-end files:
 
 . Open the `+src/custom_greeting_assets/src/index.html+` file in a text editor.
 +
-This template file is the default front-end entry point for the application as specified by the `+frontend.entrypoint+` setting in the `dfx.json` file.
+This template file is the default front-end entry point for the dapp as specified by the `+frontend.entrypoint+` setting in the `dfx.json` file.
 +
 This file contains standard HTML with references to a CSS file and an image that are located in the `+src/custom_greeting_assets/assets+` directory. 
 The default `+index.html+` file also includes standard HTML syntax for displaying an input field for the `+name+` argument and a clickable button.
@@ -175,7 +175,7 @@ document.getElementById("clickMeBtn").addEventListener("click", async () => {
 
 == Modify the front-end files
 
-You are now ready to create a new front-end for the default program.
+You are now ready to create a new front-end for the default dapp.
 
 To prepare the front-end files:
 
@@ -201,7 +201,7 @@ module: {
 },
 ----
 +
-This setting enables the program to use the `+ts-loader+` compiler for a React JavaScript `+index.jsx+` file.
+This setting enables the project to use the `+ts-loader+` compiler for a React JavaScript `+index.jsx+` file.
 Note that there's a commented section in the default `webpack.config.js` file that you can modify to add the `module` key.
 . Create a new file named `+tsconfig.json+` in the root directory for your project.
 . Open the `+tsconfig.json+` file in a text editor, then copy and paste the following into the file:
@@ -245,31 +245,31 @@ For example:
 </html>
 ----
 
-== Start the local network
+== Start the local canister execution environment
 
-Before you can build the `+custom_greeting+` project, you need to connect to the {IC} network either running locally in your development environment or running remotely on a subnet that you can access.
+Before you can build the `+custom_greeting+` project, you need to connect to either the live {platform}, or a canister execution environment running locally in your development environment.
 
-To start the network locally:
+To start the environment locally:
 
 . Open a new terminal window or tab on your local computer.
 . Navigate to the root directory for your project, if necessary.
-. Start the {IC} network on your local computer by running the following command:
+. Start the {IC} environment on your local computer by running the following command:
 +
 [source,bash]
 ----
 dfx start --background
 ----
 +
-After the local {IC} network completes its startup operations, you can continue to the next step.
+After the local {IC} environment completes its startup operations, you can continue to the next step.
 
-== Register, build, and deploy the application
+== Register, build, and deploy the dapp
 
-After you connect to the {IC} network running locally in your development environment, you can register, build, and deploy your application locally.
+After you connect to the local {IC} execution environment, you can register, build, and deploy your dapp locally.
 
-To deploy the application locally:
+To deploy the dapp locally:
 
 . Check that you are still in the root directory for your project, if needed.
-. Register, build, and deploy your application by running the following command:
+. Register, build, and deploy your dapp by running the following command:
 +
 [source,bash]
 ----
@@ -280,7 +280,7 @@ The `+dfx deploy+` command output displays information about the operations it p
 
 == View the new front-end
 
-You can now access the new front-end for the default program by entering the canister identifier for the assets canister in a browser.
+You can now access the new front-end for the default dapp by entering the canister identifier for the assets canister in a browser.
 
 To view the custom front-end:
 
@@ -326,9 +326,9 @@ For example:
 +
 image:modified-result.png[Modified greeting result]
 
-== Stop the local network
+== Stop the local execution environment
 
-After you finish experimenting with the front-end for your program, you can stop the local Internet Computer network so that it doesn’t continue running in the background.
+After you finish experimenting with the front-end for your dapp, you can stop the local canister execution environment so that it doesn’t continue running in the background.
 
 To stop the local network:
 
@@ -336,7 +336,7 @@ To stop the local network:
 
 . In the terminal that displays network operations, press Control-C to interrupt the local network process.
 
-. Stop the {IC} network by running the following command:
+. Stop the {IC} environment by running the following command:
 +
 [source,bash]
 ----

--- a/modules/developers-guide/pages/tutorials/custom-frontend.adoc
+++ b/modules/developers-guide/pages/tutorials/custom-frontend.adoc
@@ -253,7 +253,7 @@ To start the environment locally:
 
 . Open a new terminal window or tab on your local computer.
 . Navigate to the root directory for your project, if necessary.
-. Start the {IC} environment on your local computer by running the following command:
+. Start the local canister execution environment on your local computer by running the following command:
 +
 [source,bash]
 ----

--- a/modules/developers-guide/pages/tutorials/custom-frontend.adoc
+++ b/modules/developers-guide/pages/tutorials/custom-frontend.adoc
@@ -326,7 +326,7 @@ For example:
 +
 image:modified-result.png[Modified greeting result]
 
-== Stop the local execution environment
+== Stop the local canister execution environment
 
 After you finish experimenting with the front-end for your dapp, you can stop the local canister execution environment so that it doesn’t continue running in the background.
 

--- a/modules/developers-guide/pages/tutorials/my-contacts.adoc
+++ b/modules/developers-guide/pages/tutorials/my-contacts.adoc
@@ -5,11 +5,11 @@ ifdef::env-github,env-browser[:outfilesuffix:.adoc]
 :IC: Internet Computer
 :company-id: DFINITY
 
-Cascading stylesheets represent one of the most common ways to customize the user experience for an application.
-This tutorial illustrates how to add a stylesheet when you use React to create a new front-end for your project.
-If you already know how to add cascading stylesheets (CSS) to a React-based project, you can skip this tutorial.
+Cascading stylesheets are an important part of any front-end user interface. The default starter is configured to import a `main.css` file that you can edit, but you may prefer to import your stylesheet into a JavaScript file, or to use an alternate format such as Syntactically Awesome Style Sheets, aka SCSS.
+This tutorial illustrates how to configure webpack to import a stylesheet by walking through building a contact dapp.
+If you already know how to add cascading stylesheets (CSS) to a webpack-based project, you can skip this tutorial.
 
-NOTE: This tutorial illustrates using the React framework to manage the Document Object Model (DOM) for your canister.
+NOTE: This tutorial illustrates using the React framework to manage the Document Object Model (DOM) for your front-end.
 Because React has its own custom DOM syntax, you need to modify the webpack configuration to compile the front-end code, which is written in JSX. For more information about learning to use React and JSX, see link:https://reactjs.org/docs/getting-started.html[Getting started] on the https://reactjs.org/[React website].
 
 == Before you begin
@@ -23,14 +23,14 @@ For information about installing node for your local operating system and packag
 
 * You have installed the Visual Studio Code plugin for {proglang} as described in link:../../quickstart/local-quickstart{outfilesuffix}#install-vscode[Install the language editor plug-in] if you are using Visual Studio Code as your IDE.
 
-* You have stopped any {IC} network processes running on the local
+* You have stopped any local canister execution environment processes running on the local
 computer.
 
-NOTE: Because of significant changes to the handling of HTTP requests and front-end assets, this tutorial requires you to use the {sdk-short-name} version `+0.7.0+` or later. For an overview of what's changed, see this link:../../http-middleware{outfilesuffix}[article].
+NOTE: This tutorial requires you to use the {sdk-short-name} version `+0.8.0+` or later.
 
 == Create a new project
 
-To create a new project directory for your custom front-end application:
+To create a new project directory for your custom front-end dapp:
 
 . Open a terminal shell on your local computer, if you don’t already have one open.
 . Change to the folder you are using for your {IC} projects, if you are using one.
@@ -81,7 +81,7 @@ NOTE: As an alternative to installing these modules, you can edit the default `+
 include::example$add-stylesheet-package.json[]
 ....
 +
-The version of the JavaScript agent in this example `+package.json+` file is `+0.9.2+`. In most cases, however, you would want to use the latest version of the agent available. When you create a new project, the `+dfx new+` command automatically retrieves the latest version of the JavaScript agent for you. You can also manually retrieve the latest version after creating a project by running the `+npm install --save @dfinity/agent+` command.
+The version of the JavaScript agent in this example `+package.json+` file is `+0.10.0+`. In most cases, however, you would want to use the latest version of the agent available. When you create a new project, the `+dfx new+` command automatically retrieves the latest version of the JavaScript agent for you. You can also manually retrieve the latest version after creating a project by running the `+npm install --save @dfinity/agent+` command.
 
 == Modify the default program
 
@@ -125,7 +125,37 @@ module: {
 },
 ----
 +
-These settings enable your program to use the `+ts-loader+` compiler and to import CSS files.
+. These settings enable your program to use the `+ts-loader+` compiler and to import CSS files.
++
+Note: if you want to add support for `+.scss+` or `+.sass+` files, you should install `+sass-loader+` with:
++
+[source,bash]
+----
+npm install --save react react-dom
+----
++ 
+and then add this additional rule beneath the `+css-loader+` rule in `+webpack.config.js+`:
++
+[source,js]
+----
+module: {
+  rules: [
+    // ...
+    {
+      test: /\.s[ac]ss$/i,
+      use: [
+        // Creates `style` nodes from JS strings
+        "style-loader",
+        // Translates CSS into CommonJS
+        "css-loader",
+        // Compiles Sass to CSS
+        "sass-loader",
+      ],
+    },
+  ]
+},
+----
+
 . Save your changes and close the `+webpack.config.js+` file to continue.
 . Create a new file named `+tsconfig.json+` in the root directory for your project.
 . Open the `+tsconfig.json+` file in a text editor, then copy and paste the following into the file:
@@ -177,7 +207,7 @@ include::example$mycontacts/mod-index.jsx[]
 ----
 mv index.js index.jsx
 ----
-. Open the default `src/contacts_assets/src/index.html` file in a text editor, then replace `main.css` as the stylesheet file name with `mycontacts.css` and update the `body` contents with `<div id="contacts"></div>`.
+. Open the default `src/contacts_assets/src/index.html` file in a text editor, then remove the `main.css` link and update the `body` contents with `<div id="contacts"></div>`.
 +
 For example:
 +
@@ -190,8 +220,6 @@ For example:
     <meta name="viewport" content="width=device-width" />
     <title>contacts</title>
     <base href="/" />
-
-    <link type="text/css" rel="stylesheet" href="main.css" />
   </head>
   <body>
     <main>
@@ -211,29 +239,29 @@ cd ../../..
 
 == Start the local network
 
-Before you can build the `+contacts+` project, you need to connect to the {IC} network either running locally in your development environment or running remotely on a subnet that you can access.
+Before you can build the `+contacts+` project, you need to connect to the local canister execution environment.
 
-To start the network locally:
+To start the environment locally:
 
 [arabic]
 . Open a new terminal window or tab on your local computer.
-. Start the {IC} network on your local computer by running the following command:
+. Start the canister execution environment on your local computer by running the following command:
 +
 [source,bash]
 ----
 dfx start --background
 ----
 +
-After the local {IC} network completes its startup operations, you can continue to the next step.
+After the environment completes its startup operations, you can continue to the next step.
 
-== Register, build, and deploy the application
+== Register, build, and deploy the dapp
 
-After you connect to the {IC} network running locally in your development environment, you can register, build, and deploy your application locally.
+After you connect to the local canister execution environment in your development environment, you can register, build, and deploy your dapp for testing.
 
-To deploy the application:
+To deploy the dapp:
 
 . Check that you are still in the root directory for your project, if needed.
-. Register, build, and deploy your application by running the following command:
+. Register, build, and deploy your dapp by running the following command:
 +
 [source,bash]
 ----
@@ -242,10 +270,9 @@ dfx deploy
 +
 The `+dfx deploy+` command output displays information about the operations it performs.
 +
-Keep in mind that because you are running the {IC} locally, the identifiers displayed when you run the `+dfx deploy+` command are only valid on the local network.
+Keep in mind that because you are running the canister execution environment locally, the identifiers displayed when you run the `+dfx deploy+` command are only valid on your machine.
 +
-To deploy canisters on an external {IC} network, you must connect to that network using the `+--network+` command-line option and a specific network name or address to register identifiers on that network.
-For example, to deploy on the {IC} using the reserve network alias `+ic+`, you would run a command similar the following:
+To deploy canisters on the {platform}, you must specify that you are deploying to the {IC} and not your local environment by using the `+--network+` command-line option:
 +
 [source,bash]
 ----
@@ -260,7 +287,7 @@ npm start
 
 == View the front-end
 
-You can now access the front-end for the `+contacts+` program by entering the canister identifier for the assets canister in a browser.
+You can now access the front-end for the `+contacts+` dapp.
 
 To view the front-end:
 
@@ -278,11 +305,11 @@ Keep in mind that the *Lookup name* you type must be an exact match for the name
 
 == Modify the stylesheet and test your changes
 
-After viewing the Contacts application, you might want to make some changes.
+After viewing the Contacts dapp, you might want to make some changes.
 
 To change stylesheet properties:
 
-. Open the `+src/contacts_assets/public/mycontacts.css+` file in a text editor and modify its style settings.
+. Open the `+src/contacts_assets/assets/mycontacts.css+` file in a text editor and modify its style settings.
 +
 For example, you might want to change the background color or style the input form.
 +
@@ -294,14 +321,14 @@ If you want to explore further, you might want to experiment with modifying the 
 For example, you might want try modifying the tutorial to do the following:
 
 - Change the front-end code to clear the input fields after adding a new contact, for example, as part of an `+onClick+` event.
-- Change the {proglang} program functions to do partial instead of exact string matching on the `+Name+` field. (You will need to run `dfx deploy` to test your changes on the local replica)
+- Change the {proglang} program functions to do partial instead of exact string matching on the `+Name+` field. (You will need to run `dfx deploy` to test your changes on the local environment)
 - Change the {proglang} program to allow lookups based on a different field.
 
-== Stop the local network
+== Stop the local canister execution environment
 
-After you finish experimenting with your program, you can stop the local Internet Computer network so that it doesn’t continue running in the background.
+After you finish experimenting with your program, you can stop the local environment so that it doesn’t continue running in the background.
 
-To stop the local network:
+To stop the local development environment:
 
 . In the terminal that displays your webpack dev server, press Control-C to interrupt the development server.
 

--- a/modules/developers-guide/pages/tutorials/my-contacts.adoc
+++ b/modules/developers-guide/pages/tutorials/my-contacts.adoc
@@ -245,7 +245,7 @@ To start the environment locally:
 
 [arabic]
 . Open a new terminal window or tab on your local computer.
-. Start the canister execution environment on your local computer by running the following command:
+. Start the local canister execution environment on your local computer by running the following command:
 +
 [source,bash]
 ----

--- a/modules/developers-guide/pages/webpack-config.adoc
+++ b/modules/developers-guide/pages/webpack-config.adoc
@@ -1,8 +1,8 @@
-= Frontend Overview
+= Front-end Overview
 
-The {platform} allows you to host web content for your dapps, using our https://www.npmjs.com/package/@dfinity/agent[JavaScript agent]. By using the https://github.com/dfinity/certified-assets[asset canister] provided by `+dfx+` to upload static files to the {IC}, you will be able to run your entire application on decentralized technology. This section takes a closer look at the default front-end template that is provided by `+dfx new+`, front-end configuration options, and using other frameworks to build the user interface for your projects.
+The {platform} allows you to host Web 3.0 front-ends for your dapps, using our https://www.npmjs.com/package/@dfinity/agent[JavaScript agent]. By using the https://github.com/dfinity/certified-assets[asset canister] provided by `+dfx+` to upload static files to the {IC}, you will be able to run your entire application on decentralized technology. This section takes a closer look at the default front-end template that is provided by `+dfx new+`, front-end configuration options, and using other frameworks to build the user interface for your projects.
 
-Here are some quick links to tutorials with example code for various stages of developing your frontend dapp:
+Here are some quick links to tutorials with example code for various stages of developing your front-end dapp:
 
 * A tutorial on building a React dapp link:tutorials/custom-frontend{outfilesuffix}[Customize the front-end]
 * Using link:tutorials/hello-location{outfilesuffix}#candid-ui[Candid] as a bare-bones interface to expose and test the functions in a canister.

--- a/modules/developers-guide/pages/webpack-config.adoc
+++ b/modules/developers-guide/pages/webpack-config.adoc
@@ -1,14 +1,14 @@
-= Add front-end assets
+= Frontend Overview
 
-The tutorials introduced a few basic approaches to building a front-end user interface for your projects.
-For example, the tutorials demonstrated:
+The {platform} allows you to host web content for your dapps, using our https://www.npmjs.com/package/@dfinity/agent[JavaScript agent]. By using the https://github.com/dfinity/certified-assets[asset canister] provided by `+dfx+` to upload static files to the {IC}, you will be able to run your entire application on decentralized technology. This section takes a closer look at the default front-end template that is provided by `+dfx new+`, front-end configuration options, and using other frameworks to build the user interface for your projects.
 
+Here are some quick links to tutorials with example code for various stages of developing your frontend dapp:
+
+* A tutorial on building a React dapp link:tutorials/custom-frontend{outfilesuffix}[Customize the front-end]
 * Using link:tutorials/hello-location{outfilesuffix}#candid-ui[Candid] as a bare-bones interface to expose and test the functions in a canister.
 * Using link:tutorials/explore-templates{outfilesuffix}#default-frontend[raw HTML and JavaScript] to display a simple HTML entry page.
 * Using link:tutorials/custom-frontend{outfilesuffix}[React and compiled JavaScript] to embed HTML attributes and elements directly in a page.
 * Using link:tutorials/my-contacts{outfilesuffix}[React and TypeScript] to import CSS properties from an external file.
-
-This section takes a closer look at the default front-end template, front-end configuration options, and using other frameworks to build the user interface for your projects.
 
 == How the default templates are used
 
@@ -69,7 +69,7 @@ document.getElementById("clickMeBtn").addEventListener("click", async () => {
 });
 ----
 
-In many projects, you will be able to ignore the code under `+declarations+` for the most part, and make your changes in `hello_assets/src`. However, if your project has additional requirements, continue reading below.
+In many projects, you will be able to use the code under `+declarations+` without any changes, and make your changes in `hello_assets/src`. However, if your project has additional requirements, continue reading below.
 
 === Modifying the webpack configuration
 
@@ -191,7 +191,7 @@ export default Navigation;
 
 == Iterate faster using webpack-dev-server
 
-Starting with dfx 0.7.7, we now provide you with webpack dev-server in our `dfx new` starter.
+Starting with dfx 0.7.7, we now provide you with webpack dev-server in our `+dfx new+` starter.
 
 The webpack development server—`+webpack-dev-server+`—provides in-memory access to the webpack assets, enabling you to make changes and see them reflected in the browser right away using live reloading.
 
@@ -248,10 +248,10 @@ When you are done working on the front-end for your project, you can stop the we
 
 You may want to use a bundler other than webpack. Per-bundler instructions are not ready yet, but if you are familiar with your bundler, the following steps should get you going:
 
-. Remove the `copy:types`, `prestart`, and `prebuild` scripts from `package.json`
-. Run `dfx deploy` to generate the local bindings for your canisters
+. Remove the `+copy:types+`, `+prestart+`, and `+prebuild+` scripts from `+package.json+`
+. Run `+dfx deploy+` to generate the local bindings for your canisters
 . Copy the generated bindings to a directory where you would like to keep them
-. Modify `declarations/<canister_name>/index.js` and replace `process.env.<CANISTER_NAME>_CANISTER_ID` with the equivalent pattern for environment variables for your bundler
+. Modify `+declarations/<canister_name>/index.js+` and replace `+process.env.<CANISTER_NAME>_CANISTER_ID+` with the equivalent pattern for environment variables for your bundler
   * Alternately hardcode the canister ID if that is your preferred workflow
 . Commit the declarations and import them in your codebase
 


### PR DESCRIPTION
Changes around local network, blockchain and so on. 

I've also refreshed package versions to their current state and made some editorial improvements to a couple of the pages, based on my own judgment as the inheritor of these tutorials

The CSS tutorial had become redundant due to my improvements to the starter project, so I adapted it as a guide on how to import styles into JS, as well as configuring sass, a popular superset of the CSS language