### PR TITLE
Instruct users to add to PATH, not replace

### DIFF
--- a/modules/quickstart/pages/newcomers.adoc
+++ b/modules/quickstart/pages/newcomers.adoc
@@ -143,7 +143,7 @@ If the `+dfx+` executable is not in one of the directories listed in your curren
 The specific steps for updating the `+PATH+` depend on your operating system, but, in many cases, you can run a command similar to the following and specifying the appropriate directory, such as `+~/bin+`:
 
 ....
-export PATH=<path-to-directory-for-dfx>
+export PATH="<path-to-directory-for-dfx>:$PATH"
 ....
 
 Now you're ready to link:local-quickstart{outfilesuffix}#download-and-install[install] the {sdk-short-name} and get coding!


### PR DESCRIPTION
`export PATH=<newpath>` will override the existing path and could really mess up a newcomer's computer without them understanding why. Instead, new paths should be added with syntax like:
`export PATH=<newpath>:$PATH" which will just prepend the new path

See https://linuxize.com/post/how-to-add-directory-to-path-in-linux/ for corroboration

**Overview**
Why do we need this feature? What are we trying to accomplish?

**Requirements**
What requirements are necessary to consider this problem solved?

**Considered Solutions**
What solutions were considered?

**Recommended Solution**
What solution are you recommending? Why?

**Considerations**
What impact will this change have on security, performance, users (e.g. breaking changes) or the team (e.g. maintenance costs)?
