### PR TITLE
Removed unnecessary `for` in the documentation

### DIFF
--- a/modules/developers-guide/pages/work-with-languages.adoc
+++ b/modules/developers-guide/pages/work-with-languages.adoc
@@ -13,7 +13,7 @@ This section provides a summary of the key steps involved in deploying a Rust pr
 You should note, however, that the steps described here only illustrate one approach. 
 Other implementation approaches are also possible. 
 
-Note that the link:https://github.com/dfinity/cdk-rs[Rust canister development kit (Rust CDK)] for provides some shortcuts to make it easier to write functions as query and update calls and includes several link:https://github.com/dfinity/cdk-rs/tree/next/examples[examples] to get you started building Rust-based projects, but you can also develop dapps for the {IC} without using the Rust CDK.
+Note that the link:https://github.com/dfinity/cdk-rs[Rust canister development kit (Rust CDK)] provides some shortcuts to make it easier to write functions as query and update calls and includes several link:https://github.com/dfinity/cdk-rs/tree/next/examples[examples] to get you started building Rust-based projects, but you can also develop dapps for the {IC} without using the Rust CDK.
 
 === Create a project
 


### PR DESCRIPTION
**Overview**
Why do we need this feature? What are we trying to accomplish?
There was a small typo / grammatical error in the docs. 

**Requirements**
What requirements are necessary to consider this problem solved?
N/A

**Considered Solutions**
What solutions were considered?
N/A

**Recommended Solution**
What solution are you recommending? Why?
* Remove the existing `for` 
* Or replace it with `for Rust`

**Considerations**
What impact will this change have on security, performance, users (e.g. breaking changes) or the team (e.g. maintenance costs)?
N/A
