### PR TITLE
Delete sentence with dead link

### DIFF
--- a/modules/token-holders/pages/nns-app-quickstart.adoc
+++ b/modules/token-holders/pages/nns-app-quickstart.adoc
@@ -391,7 +391,6 @@ Currently, you can only submit proposals to the network nervous system by using 
 A separate command-line tool (`+icx-nns+`) for working with the `+governance+` canister is in development and this functionality will also be available in the link:https://nns.ic0.app[Network Nervous System (NNS)] dapp soon.
 
 If you want to start submitting proposals right away, however, you can access a preliminary version of the `+icx-nns+` command-line tool by downloading a release from the link:https://github.com/dfinity/icx-nns/releases[icx-nns] repository. 
-For information about how to download the `+icx-nns+` command-line tool and how to use it to submit proposals, see https://www.internetcomputer.org/governance/submit-proposal[How to submit proposals to the Network Nervous System].
 
 == Deploy a canister with cycles
 


### PR DESCRIPTION
As pointed out on slack, I propose to delete this sentence as it has a dead link and, apart from the link, does not add any extra information.

**Overview**
Why do we need this feature? What are we trying to accomplish?

**Requirements**
What requirements are necessary to consider this problem solved?

**Considered Solutions**
What solutions were considered?

**Recommended Solution**
What solution are you recommending? Why?

**Considerations**
What impact will this change have on security, performance, users (e.g. breaking changes) or the team (e.g. maintenance costs)?
