### PR TITLE
Updated 'Build the dapp' in explore-templates.adoc

### DIFF
--- a/modules/developers-guide/pages/tutorials/explore-templates.adoc
+++ b/modules/developers-guide/pages/tutorials/explore-templates.adoc
@@ -311,6 +311,13 @@ In addition to the files in the `+canisters/explore_hello+` and the `+canisters/
 . Verify that a new folder has been created, `src/declarations`.
 +
 This folder will include copies of the folders from `.dfx/local`, except for the wasm. They do not contain any secrets, and we recommend committing these files along with the rest of your source code.
++
+If the `src/declarations` folder was not created, use the the following command:
++
+[source,bash]
+----
+dfx generate
+----
 
 == Deploy the project locally
 


### PR DESCRIPTION
Added a short description how to generate the 'src/declarations' folder by calling 'dfc generate', because it doesn't get generated by calling 'dfx build'

**Overview**
Why do we need this feature? What are we trying to accomplish?

**Requirements**
What requirements are necessary to consider this problem solved?

**Considered Solutions**
What solutions were considered?

**Recommended Solution**
What solution are you recommending? Why?

**Considerations**
What impact will this change have on security, performance, users (e.g. breaking changes) or the team (e.g. maintenance costs)?
