### PR TITLE
Include rosetta docs into the navigation tree

### DIFF
--- a/antora.yml
+++ b/antora.yml
@@ -11,6 +11,7 @@ nav:
   #- modules/language-guide/lang-nav.adoc
   # - modules/interface-spec/ic-nav.adoc
   - modules/base-libraries/lib-nav.adoc
+  - modules/rosetta-api/rosetta-nav.adoc
   #- modules/rust-guide/rust-nav.adoc
   #- modules/integration/integration-nav.adoc
   #- modules/operators-guide/ops-nav.adoc


### PR DESCRIPTION
This change adds Rosetta API documentation to the navigation tree.
I added docs in Antora-compatible format in this commit: https://github.com/dfinity/ic/commit/b415274ccfdd64c8a7b8ae92883c17cca62ada4b
I add the rosetta-api module to the playbook in this PR: https://github.com/dfinity/dfinity-docs-playbook/pull/72

I tested my changes locally, everything seems to work as expected.