### PR TITLE
fix typo in ledger quick start

### DIFF
--- a/modules/integration/pages/ledger-quick-start.adoc
+++ b/modules/integration/pages/ledger-quick-start.adoc
@@ -213,7 +213,7 @@ The following questions are taken from the most commonly reported questions and 
 
 === The Rosetta node
 
-==== How to I run an instance of the Rosetta node?
+==== How do I run an instance of the Rosetta node?
 
 An easy way to accomplish this is to use the link:https://hub.docker.com/r/dfinity/rosetta-api/tags?page=1&ordering=last_updated[`dfinity/rosetta-api`] Docker image. Once the node initializes and syncs all blocks, you can perform queries and submit transactions by invoking the Rosetta API on the node. The node listens on the `8080` port.
 


### PR DESCRIPTION
I found a tiny typo: 
"How to I run ~~" -> "How do I run ~~"

**Overview**
Why do we need this feature? What are we trying to accomplish?

**Requirements**
What requirements are necessary to consider this problem solved?

**Considered Solutions**
What solutions were considered?

**Recommended Solution**
What solution are you recommending? Why?

**Considerations**
What impact will this change have on security, performance, users (e.g. breaking changes) or the team (e.g. maintenance costs)?
