### PR TITLE
chore: fix broken links in host a website

### DIFF
--- a/modules/quickstart/pages/host-a-website.adoc
+++ b/modules/quickstart/pages/host-a-website.adoc
@@ -1,7 +1,7 @@
 Hosting a Static Website on the Internet Computer
 =================================================
 
-Before you begin, make sure you are set up with our {sdk-short-name} (DFX) and a Cycles Wallet, either from the xref:quickstart:cycles-faucet.adoc[Faucet Quickstart] or by purchasing ICP and following our xref:quickstart:network-quickstart.adoc[Network Deployment] guide.
+Before you begin, make sure you are set up with our {sdk-short-name} (DFX) and a Cycles Wallet, either from the link:cycles-faucet{outfilesuffix}[Faucet Quickstart] or by purchasing ICP and following our link:network-quickstart{outfilesuffix}[Network Deployment] guide.
 
 == Set up your project
 


### PR DESCRIPTION
the xref links to  the faucet quickstart and network deployment are broken. This replaces those with the `link:` pattern

https://deploy-preview-668--dfinity-docs-preview.netlify.app/docs/quickstart/host-a-website.html

![Screen Shot 2022-01-31 at 4 08 22 PM](https://user-images.githubusercontent.com/16298804/151893439-e2199c32-8e1e-4eff-bc87-6f4cdb3dcb2c.png)

