### PR TITLE
fix: broken link to 0.9.0 release notes

### DIFF
--- a/modules/release-notes/pages/0.9.2-rn.adoc
+++ b/modules/release-notes/pages/0.9.2-rn.adoc
@@ -8,7 +8,7 @@ ifdef::env-github,env-browser[:outfilesuffix:.adoc]
 
 An overview of the {release} release:
 
-Be sure to see the link:0.9.0-rn.adoc[0.9.0 Release Notes] and follow the instructions due to breaking changes since dfx 0.8.4.
+Be sure to see the link:0.9.0-rn[0.9.0 Release Notes] and follow the instructions due to breaking changes since dfx 0.8.4.
 
 == Changes to DFX
 


### PR DESCRIPTION
The existing link goes to https://smartcontracts.org/docs/release-notes/0.9.0-rn.adoc . Removing the extension will make the link refer to https://smartcontracts.org/docs/release-notes/0.9.0-rn.html .

Verified here: https://deploy-preview-684--dfinity-docs-preview.netlify.app/docs/release-notes/0.9.2-rn
links to https://deploy-preview-684--dfinity-docs-preview.netlify.app/docs/release-notes/0.9.0-rn

