### PR TITLE
Add to dfx 0.9.2 release notes: remote canisters, generate remote bindings

### DIFF
--- a/modules/release-notes/pages/0.9.2-rn.adoc
+++ b/modules/release-notes/pages/0.9.2-rn.adoc
@@ -93,6 +93,122 @@ dfx now calls `transfer` rather than `send_dfx`, and sets the created_at_time fi
 * dfx ledger top-up
 * dfx ledger transfer
 
+=== New Feature: Remote canister support
+
+It's now possible to specify that a canister in dfx.json references a "remote" canister on a specific network,
+that is, a canister that already exists on that network and is managed by some other project.
+
+Motoko, Rust, and custom canisters may be configured in this way.
+
+This is the general format of the configuration in dfx.json:
+[source, json]
+----
+{
+  "canisters": {
+    "<canister name>": {
+      "remote": {
+        "candid": "<path to candid file to use when building on remote networks>"
+        "id": {
+          "<network name>": "<principal on network>"
+        }
+      }
+    }
+  }
+}
+----
+
+The "id" field, if set for a given network, specifies the canister ID for the canister on that network.
+The canister will not be created or installed on these remote networks.
+For other networks, the canister will be created and installed as usual.
+
+The "candid" field, if set within the remote object, specifies the candid file to build against when
+building other canisters on a network for which the canister is remote.  This definition can differ
+from the candid definitions for local builds.
+
+For example, if have an installation of the ICP Ledger (see https://github.com/dfinity/ic/tree/master/rs/rosetta-api/ledger_canister#deploying-locally[Ledger Installation Guide])
+in your dfx.json, you could configure the canister ID of the Ledger canister on the ic network as below.  In this case,
+the private interfaces would be available for local builds, but only the public interfaces would be available
+when building for `--network ic`.
+[source, json]
+----
+{
+  "canisters": {
+    "ledger": {
+      "type": "custom",
+      "wasm": "ledger.wasm",
+      "candid": "ledger.private.did",
+      "remote": {
+        "candid": "ledger.public.did",
+        "id": {
+          "ic": "ryjl3-tyaaa-aaaaa-aaaba-cai"
+        }
+      }
+    },
+    "app": {
+      "type": "motoko",
+      "main": "src/app/main.mo",
+      "dependencies": [ "ledger" ]
+    }
+  }
+}
+----
+
+As a second example, suppose that you wanted to write a mock of the ledger in Motoko.
+In this case, since the candid definition is provided for remote networks,
+`dfx build` (with implicit `--network local`) will build app against the candid
+definitions defined by mock.mo, but `dfx build --network ic` will build app against
+`ledger.public.did`.
+
+This way, you can define public update/query functions to aid in local testing, but
+when building/deploying to mainnet, references to methods not found in `ledger.public.did`
+will be reports as compilation errors.
+
+[source, json]
+----
+{
+  "canisters": {
+    "ledger": {
+      "type": "motoko",
+      "main": "src/ledger/mock.mo",
+      "remote": {
+        "candid": "ledger.public.did",
+        "id": {
+          "ic": "ryjl3-tyaaa-aaaaa-aaaba-cai"
+        }
+      }
+    },
+    "app": {
+      "type": "motoko",
+      "main": "src/app/main.mo",
+      "dependencies": [ "ledger" ]
+    }
+  }
+}
+----
+
+=== New Feature: Generating remote canister bindings
+
+It's now possible to generate the interface of a remote canister using a .did file using the `dfx remote generate-binding <canister name>|--all` command. This makes it easier to write mocks for local development.
+
+Currently, dfx can generate .mo, .rs, .ts, and .js bindings.
+
+This is how you specify how to generate the bindings in dfx.json:
+[source, json]
+----
+{
+  "canisters": {
+    "<canister name>": {
+      "main": "<path to mo/rs/ts/js file that will be generated>",
+      "remote": {
+        "candid": "<path to candid file to use when generating bindings>"
+        "id": {}
+      }
+    }
+  }
+}
+----
+
+
 == Motoko
 
 Updated Motoko from 0.6.20 to 0.6.21.


### PR DESCRIPTION
I missed these when writing the dfx 0.9.2 release notes.