### PR TITLE
chore: replaces all references  to sdk.dfinity.org 

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -13,11 +13,11 @@ Your participation is an important factor in the success of the Internet Compute
 This repository contains the documentation source files for the DFINITY Canister Software Development Kit (SDK).
 The files use AsciiDoctor markup language.
 
-This repository also contains the `antora.yml` configuration file that lists the documentation components (modules) and versions included in the [documentation website](https://sdk.dfinity.org).
+This repository also contains the `antora.yml` configuration file that lists the documentation components (modules) and versions included in the [documentation website](https://smartcontracts.org).
 
 The navigation for all modules—including documentation for modules located in other repositories—is stored in the under the ROOT module in the `nav.adoc` file.
 
-The [documentation website](https://sdk.dfinity.org) is generated using the [Antora](https://docs.antora.org/antora/2.2/install/install-antora/) static site generator.
+The [documentation website](https://smartcontracts.org) is generated using the [Antora](https://docs.antora.org/antora/2.2/install/install-antora/) static site generator.
 
 The `antora-playbook.yml` identifies the repository branches and UI bundle to use in building the documentation site.
 The playbook is located in a separate repository.

--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
 
 You can get started right away by downloading the Internet Computer Software Development Kit (SDK) and cloning an existing sample project or by exploring the documentation. Check out the links below to begin building smart contract canisters to run on the Internet Computer:
 
-- [*Get the SDK*](https://sdk.dfinity.org/docs/download.html) Download the SDK for the Internet Computer.
-- [*Quick Start*](https://sdk.dfinity.org/docs/quickstart/quickstart-intro.html) Deploy your first app on the Internet Computer.
+- [*Get the SDK*](https://smartcontracts.org/docs/download.html) Download the SDK for the Internet Computer.
+- [*Quick Start*](https://smartcontracts.org/docs/quickstart/quickstart-intro.html) Deploy your first app on the Internet Computer.
 - [*Examples Repository*](https://github.com/dfinity/examples) Explore on your own in the examples repository.
-- [*Language Guide*](https://sdk.dfinity.org/docs/language-guide/motoko.html) Explore the Motoko programming language.
-- [*Videos*](https://sdk.dfinity.org/docs/videos-tutorials.html) Watch the _Building Applications for the Internet Computer: Fundamentals_ video series.
+- [*Language Guide*](https://smartcontracts.org/docs/language-guide/motoko.html) Explore the Motoko programming language.
+- [*Videos*](https://smartcontracts.org/docs/videos-tutorials.html) Watch the _Building Applications for the Internet Computer: Fundamentals_ video series.
 
 # Contributing to the documentation
 

--- a/modules/ROOT/pages/download.adoc
+++ b/modules/ROOT/pages/download.adoc
@@ -21,7 +21,7 @@ For example, on macOS open the Applications folder, then open Utilities and doub
 +
 [source,bash]
 ----
-sh -ci "$(curl -fsSL https://sdk.dfinity.org/install.sh)"
+sh -ci "$(curl -fsSL https://smartcontracts.org/install.sh)"
 ----
 
 [[install-version]]
@@ -39,7 +39,7 @@ For example, to install version 0.9.3, you would run the following command:
 +
 [source,bash]
 ----
-DFX_VERSION=0.9.3 sh -ci "$(curl -fsSL https://sdk.dfinity.org/install.sh)"
+DFX_VERSION=0.9.3 sh -ci "$(curl -fsSL https://smartcontracts.org/install.sh)"
 ----
 
 NOTE: If you are using the DFX_VERSION environment variable to install a version of the {sdk-short-name} not yet publicly available, see this link:http-middleware{outfilesuffix}[article] for an overview of what's changed. 

--- a/modules/ROOT/pages/index.adoc
+++ b/modules/ROOT/pages/index.adoc
@@ -22,11 +22,11 @@ window.location.replace("https://dfinity.org/developers");
 
 [source,bash]
 ----
-sh -ci "$(curl -fsSL https://sdk.dfinity.org/install.sh)"
+sh -ci "$(curl -fsSL https://smartcontracts.org/install.sh)"
 ----
 
 ++++
-        <p>By installing the SDK, you agree to our <a href="https://sdk.dfinity.org/sdk-license-agreement.txt">Terms & Conditions</a>.</p>
+        <p>By installing the SDK, you agree to our <a href="https://smartcontracts.org/sdk-license-agreement.txt">Terms & Conditions</a>.</p>
         </div>
     </div>
 

--- a/modules/ROOT/pages/search.adoc
+++ b/modules/ROOT/pages/search.adoc
@@ -6,7 +6,7 @@ Type a string of at least two characters, then click Search.
 ++++
 <form action="https://www.google.com/search" id="form-search">
 <label class="search" for="input-search">Type search criteria:</label>
-<input type="text" name="q" class="search-input input-inline" id="input-search" autofocus="on" placeholder="Search..." value=" site:sdk.dfinity.org ">
+<input type="text" name="q" class="search-input input-inline" id="input-search" autofocus="on" placeholder="Search..." value=" site:smartcontracts.org ">
 <button type="submit" class="btn-search" id="submit-search">
 <svg xmlns="http://www.w3.org/2000/svg" style="height: 1em; width: 1em;" viewBox="0 0 32 32" aria-labelledby="search-title"><title id="search-title">Search</title><path fill="currentColor" d="M31.008 27.23l-7.58-6.446c-.784-.705-1.622-1.03-2.3-.998C22.92 17.69 24 14.97 24 12 24 5.37 18.627 0 12 0S0 5.37 0 12c0 6.626 5.374 12 12 12 2.973 0 5.692-1.082 7.788-2.87-.03.676.293 1.514.998 2.298l6.447 7.58c1.105 1.226 2.908 1.33 4.008.23s.997-2.903-.23-4.007zM12 20c-4.418 0-8-3.582-8-8s3.582-8 8-8 8 3.582 8 8-3.582 8-8 8z"></path></svg>
 </button>

--- a/modules/developers-guide/pages/cli-reference/dfx-envars.adoc
+++ b/modules/developers-guide/pages/cli-reference/dfx-envars.adoc
@@ -49,5 +49,5 @@ The `+.cache/dfinity/uninstall.sh+` script uses this environment variable to ide
 Use the `+DFX_VERSION+` environment variable to identify a specific version of the {sdk-short-name} that you want to install.
 
 ....
-DFX_VERSION=0.9.3 sh -ci "$(curl -fsSL https://sdk.dfinity.org/install.sh)"
+DFX_VERSION=0.9.3 sh -ci "$(curl -fsSL https://smartcontracts.org/install.sh)"
 ....

--- a/modules/developers-guide/pages/cli-reference/dfx-upgrade.adoc
+++ b/modules/developers-guide/pages/cli-reference/dfx-upgrade.adoc
@@ -51,6 +51,6 @@ If a newer version of `+dfx+` is available, the command automatically downloads 
 [source,bash]
 ----
 Current version: 0.6.8
-Fetching manifest \https://sdk.dfinity.org/manifest.json
+Fetching manifest \https://smartcontracts.org/manifest.json
 Already up to date
 ----

--- a/modules/developers-guide/pages/install-upgrade-remove.adoc
+++ b/modules/developers-guide/pages/install-upgrade-remove.adoc
@@ -107,5 +107,5 @@ If you are uninstalling because you want to immediately reinstall a clean versio
 
 [source,bash]
 ----
-~/.cache/dfinity/uninstall.sh && sh -ci "$(curl -sSL https://sdk.dfinity.org/install.sh)"
+~/.cache/dfinity/uninstall.sh && sh -ci "$(curl -sSL https://smartcontracts.org/install.sh)"
 ----

--- a/modules/developers-guide/pages/troubleshooting.adoc
+++ b/modules/developers-guide/pages/troubleshooting.adoc
@@ -76,14 +76,14 @@ If you only have one version of `+dfx+` installed in your development environmen
 
 [source,bash]
 ----
-~/.cache/dfinity/uninstall.sh && sh -ci "$(curl -sSL https://sdk.dfinity.org/install.sh)"
+~/.cache/dfinity/uninstall.sh && sh -ci "$(curl -sSL https://smartcontracts.org/install.sh)"
 ----
 
 If you have modified the location of the `+dfx+` binary, you might want run the following command to uninstall the version of `+dfx+` that is in your PATH, then reinstall the latest version of `+dfx+`:
 
 [source,bash]
 ----
-rm -rf ~/.cache/dfinity && rm $(which dfx) && sh -ci "$(curl -sSL https://sdk.dfinity.org/install.sh)"
+rm -rf ~/.cache/dfinity && rm $(which dfx) && sh -ci "$(curl -sSL https://smartcontracts.org/install.sh)"
 ----
 
 == Xcode prerequisite
@@ -154,5 +154,5 @@ Alternatively, you can remove the `+.cache/dfinity+` directory and re-install th
 For example:
 [source,bash]
 ----
-rm -rf ~/.cache/dfinity && sh -ci "$(curl -sSL https://sdk.dfinity.org/install.sh)"
+rm -rf ~/.cache/dfinity && sh -ci "$(curl -sSL https://smartcontracts.org/install.sh)"
 ----

--- a/modules/developers-guide/pages/tutorials/reproducible-builds.adoc
+++ b/modules/developers-guide/pages/tutorials/reproducible-builds.adoc
@@ -120,7 +120,7 @@ RUN curl --fail https://sh.rustup.rs -sSf \
 
 # Install dfx; the version is picked up from the DFX_VERSION environment variable
 ENV DFX_VERSION=0.9.3
-RUN sh -ci "$(curl -fsSL https://sdk.dfinity.org/install.sh)"
+RUN sh -ci "$(curl -fsSL https://smartcontracts.org/install.sh)"
 
 COPY . /canister
 WORKDIR /canister
@@ -232,7 +232,7 @@ RUN curl --fail https://sh.rustup.rs -sSf \
 
 # Install dfx; the version is picked up the DFX_VERSION environment variable
 ENV DFX_VERSION=0.9.3
-RUN sh -ci "$(curl -fsSL https://sdk.dfinity.org/install.sh)"
+RUN sh -ci "$(curl -fsSL https://smartcontracts.org/install.sh)"
 
 RUN apt -yqq install --no-install-recommends reprotest disorderfs faketime sudo wabt
 

--- a/modules/integration/pages/ledger-quick-start.adoc
+++ b/modules/integration/pages/ledger-quick-start.adoc
@@ -251,7 +251,7 @@ Start `dfinity/rosetta-api` with `--help`, you can see some additional CLI argum
 
 - Generate an ED25519 keypair.
 - The secret key is used for signing transactions.
-- The public key is used for generating a self-authenticating Principal ID. For more information, see: https://sdk.dfinity.org/docs/interface-spec/index.html#_principals.
+- The public key is used for generating a self-authenticating Principal ID. For more information, see: https://smartcontracts.org/docs/interface-spec/index.html#_principals.
 - The Principal ID is hashed to generate the account address.
 
 ==== How to use the public key to generate its account address?

--- a/modules/introduction/pages/welcome.adoc
+++ b/modules/introduction/pages/welcome.adoc
@@ -14,7 +14,7 @@ To download the Internet Computer SDK, run the following command in your termina
 
 [source,bash]
 ----
-sh -ci "$(curl -fsSL https://sdk.dfinity.org/install.sh)"
+sh -ci "$(curl -fsSL https://smartcontracts.org/install.sh)"
 ----
 
 NOTE: Qualified developers can access $20 worth of free cycles to begin deploying canister smart contracts to the Internet Computer blockchain. https://faucet.dfinity.org/auth[Claim your free cycles]

--- a/modules/quickstart/pages/1-quickstart.adoc
+++ b/modules/quickstart/pages/1-quickstart.adoc
@@ -9,7 +9,7 @@ The Canister SDK used to develop on the IC is called `dfx` and it is maintained 
 To install, one needs to run:
 [source,bash]
 ----
-sh -ci "$(curl -fsSL https://sdk.dfinity.org/install.sh)"
+sh -ci "$(curl -fsSL https://smartcontracts.org/install.sh)"
 ----
 
 To verify that it has properly installed:

--- a/modules/quickstart/pages/local-quickstart.adoc
+++ b/modules/quickstart/pages/local-quickstart.adoc
@@ -44,7 +44,7 @@ For example, open Applications, Utilities, then double-click *Terminal* or press
 +
 [source,bash]
 ----
-sh -ci "$(curl -fsSL https://sdk.dfinity.org/install.sh)"
+sh -ci "$(curl -fsSL https://smartcontracts.org/install.sh)"
 ----
 +
 This command prompts you to read and accept the license agreement before installing the {company-id} execution command-line interface (CLI) and its dependencies on your local computer.

--- a/modules/quickstart/pages/network-quickstart.adoc
+++ b/modules/quickstart/pages/network-quickstart.adoc
@@ -55,7 +55,7 @@ For example, open Applications, Utilities, then double-click *Terminal* or press
 +
 [source,bash]
 ----
-sh -ci "$(curl -fsSL https://sdk.dfinity.org/install.sh)"
+sh -ci "$(curl -fsSL https://smartcontracts.org/install.sh)"
 ----
 +
 This command prompts you to read and accept the license agreement before installing the {company-id} execution command-line interface (CLI) and its dependencies on your local computer.

--- a/modules/samples/pages/dao.adoc
+++ b/modules/samples/pages/dao.adoc
@@ -31,7 +31,7 @@ View the https://github.com/dfinity/examples/blob/master/rust/basic_dao/src/basi
 // * You have installed [didc](https://github.com/dfinity/candid/tree/master/tools/didc)
 
 // * You have downloaded and installed the [DFINITY Canister
-//    SDK](https://sdk.dfinity.org).
+//    SDK](https://smartcontracts.org).
 
 // * You have stopped any Internet Computer or other network process that would
 //    create a port conflict on 8000.

--- a/modules/token-holders/pages/self-custody-quickstart.adoc
+++ b/modules/token-holders/pages/self-custody-quickstart.adoc
@@ -48,7 +48,7 @@ To get started, verify the following:
 +
 [source,bash]
 ----
-sh -ci "$(curl -fsSL https://sdk.dfinity.org/install.sh)"
+sh -ci "$(curl -fsSL https://smartcontracts.org/install.sh)"
 ----
 
 * You have created a backup copy of the public/private key for the identity you are using for self-custody.


### PR DESCRIPTION
with smartcontracts.org

**Overview**
The old instructions cause certificate failures when people try to download the SDK