### PR TITLE
Add CodeLabs back to menu

### DIFF
--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -188,6 +188,7 @@
 *** link:http://faucet.dfinity.org/[Cycles Faucet^]
 
 ** xref:developers-guide:computation-and-storage-costs.adoc[Computation and Storage Costs]
+** xref:samples:codelabs.adoc[CodeLabs Tutorials]
 
 * Community
 ** link:https://discord.gg/cA7y6ezyE2[Developer Discord^]


### PR DESCRIPTION
**Overview**
There's an interest from the community to contribute to the CodeLabs tutorials, so adding it back in to the docs.